### PR TITLE
TextureArray nodes - name changes and functionality

### DIFF
--- a/help/Explanation Overview of available TextureArray Nodes.vl
+++ b/help/Explanation Overview of available TextureArray Nodes.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="MWrdDmleRRAMuy7FvGSdi0" LanguageVersion="2022.5.0-0696-g73767f5671" Version="0.128">
-  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0696-g73767f5671" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="MWrdDmleRRAMuy7FvGSdi0" LanguageVersion="2022.5.0-0735-ge3039d4101" Version="0.128">
+  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0735-ge3039d4101" />
   <Patch Id="S25Gr1WMWcMQSRiHRWO4uq">
     <Canvas Id="GH8DZEWEW7hN2B8H0Xzxf8" DefaultCategory="Stride" CanvasType="FullCategory" />
     <!--
@@ -15,7 +15,6 @@
       </p:NodeReference>
       <Patch Id="R8yS9f66hKqPamToAb385Y">
         <Canvas Id="SEGevHNIoA4NfVQPE4QTGK" CanvasType="Group">
-          <Pad Id="AipwsZsWZ1fLkeZHdMomDI" Comment="" Bounds="1554,2514,220,220" ShowValueBox="true" isIOBox="true" />
           <Node Bounds="294,105,87,19" Id="GJhV14MaQqoPzhRyDNVlTq">
             <p:NodeReference LastCategoryFullName="System.Application" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -97,12 +96,12 @@
             <Pin Id="VxmfFpcxoT7QcWMsNejIdY" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="SMWflJ9d8shLi1QKuZ4SER" Comment="Load As SRGB" Bounds="266,583,35,31" ShowValueBox="true" isIOBox="true" Value="True">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Boolean" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="UCWpa9i6LODPEO0oO5ys1n" Bounds="263,509,214,69" ShowValueBox="true" isIOBox="true" Value="If  the File is already SRGB like a BC7_unorm_SRGB dds the option is ignogred">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -132,7 +131,7 @@
             <Pin Id="OLrsyWoktzfNkXdhW3VJ9F" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="QlIth9z2NeyNccailcpO7G" Bounds="21,631,203,116" ShowValueBox="true" isIOBox="true" Value="Blocking (async doesn't work). Afaik all the &quot;packing&quot; happens on  the CPU.&#xD;&#xA;&#xD;&#xA;If the image files don't contain mips, none are created.">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -141,7 +140,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="HV9RSIVsNyOK9tbmofv4TC" Bounds="661,633,263,75" ShowValueBox="true" isIOBox="true" Value="Uses GraphicsContext.CommandList.CopyRegion&#xD;&#xA;Afaik Everything is done on  the GPU.">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -150,7 +149,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="EGXtyWxRSuRQC9KnRUEQoh" Bounds="1278,636,233,78" ShowValueBox="true" isIOBox="true" Value="Same wrapped in an AsyncTask.&#xD;&#xA;Not sure about that one, uses some&#xD;&#xA;dodgy logic to dispose of the TextureArray.">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -326,7 +325,7 @@
             </Patch>
           </Node>
           <Pad Id="VpJG62fTLtePA5Niqwvuku" Comment="Count" Bounds="591,1231,20,15" ShowValueBox="true" isIOBox="true" Value="4">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
@@ -343,7 +342,7 @@
             <Pin Id="CXTwqcMpWe2NfAvIPPT3Vy" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="HPewaF6YNJtNEIgRWppPPG" Comment="Scaling" Bounds="209,1411,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
@@ -516,7 +515,7 @@
             </Patch>
           </Node>
           <Pad Id="Avpaq6kgT3kPfo9xo36GAO" Comment="Count" Bounds="1142,1234,20,15" ShowValueBox="true" isIOBox="true" Value="4">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
@@ -533,7 +532,7 @@
             <Pin Id="UkFMe8NVePELmWzuwObUFP" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="EviRBdeoBKXLHZL6bxYqMR" Comment="Scaling" Bounds="760,1414,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
@@ -648,7 +647,7 @@
             <Pin Id="H7m2w7h4g9OQKDgPlITHuh" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="Nsb5VxMNYckN32GB9bmYLG" Comment="Indices" Bounds="954,756,30,141" ShowValueBox="true" isIOBox="true" Value="1, 0, 3, 2">
-            <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.Collections.vl">
+            <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Spread" />
               <p:TypeArguments>
                 <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
@@ -661,7 +660,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Node Bounds="952,902,57,19" Id="OVTIgz0YU1ELfAJIIP2nvG">
-            <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
+            <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Changed" />
             </p:NodeReference>
@@ -670,7 +669,7 @@
             <Pin Id="I7OQlFIbrFaMDsV9zBiJxz" Name="Unchanged" Kind="OutputPin" />
           </Node>
           <Node Bounds="832,931,125,19" Id="PhxreQIzFVuO6LnlMVmwe1">
-            <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.Graphics.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
             </p:NodeReference>
@@ -717,11 +716,15 @@
               <Choice Kind="ApplicationStatefulRegion" Name="If" />
             </p:NodeReference>
             <Pin Id="UDDMvQpu28AQEFWUxvdIoD" Name="Condition" Kind="InputPin" />
+            <ControlPoint Id="EN4EDtpuG9uLZyQnwwblI4" Bounds="1397,1201" Name="Tex" Alignment="Bottom" />
+            <ControlPoint Id="I1QNXRhVNriM0McDyPLjDl" Bounds="1397,1128" Name="Tex" Alignment="Top" />
+            <ControlPoint Id="K6aT5964pjmOuBvkPITYs0" Bounds="1460,1201" Name="Desc" Alignment="Bottom" />
+            <ControlPoint Id="Kq8dkBzCs2LLpOkLLvv80d" Bounds="1458,1128" Name="Desc" Alignment="Top" />
             <Patch Id="PCqWDWIPobXQRPV7V8eaH3" ManuallySortedPins="true">
               <Patch Id="Aodcu11ntfbQZVGUAUPf4H" Name="Create" ManuallySortedPins="true" />
               <Patch Id="GfUc6mcTmPoORgZNeZnc27" Name="Then" ManuallySortedPins="true" />
               <Node Bounds="1395,1150,68,26" Id="NOq4OZOfgWzPnPrnWYq1RR">
-                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Description" />
                   <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
@@ -735,10 +738,6 @@
                 <Pin Id="HJp7CHPIlYRL1sOcja9tHR" Name="Description" Kind="OutputPin" />
               </Node>
             </Patch>
-            <ControlPoint Id="EN4EDtpuG9uLZyQnwwblI4" Bounds="1397,1201" Name="Tex" Alignment="Bottom" />
-            <ControlPoint Id="I1QNXRhVNriM0McDyPLjDl" Bounds="1397,1128" Name="Tex" Alignment="Top" />
-            <ControlPoint Id="K6aT5964pjmOuBvkPITYs0" Bounds="1460,1201" Name="Desc" Alignment="Bottom" />
-            <ControlPoint Id="Kq8dkBzCs2LLpOkLLvv80d" Bounds="1458,1128" Name="Desc" Alignment="Top" />
           </Node>
           <Node Bounds="1459,1356,78,19" Id="N1hDToDTw8hLScTyjogneM">
             <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
@@ -753,7 +752,7 @@
             <Pin Id="LGqqsV6wOOwNFuczZUv7Vy" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="SUSv6XeLX2rMcSKEvQToVP" Comment="SIze" Bounds="1461,1304,35,28" ShowValueBox="true" isIOBox="true" Value="512, 512">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Int2" />
             </p:TypeAnnotation>
           </Pad>
@@ -765,8 +764,8 @@
             </p:NodeReference>
             <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">Low</p:HelpFocus>
             <Pin Id="IWbOBFYlwXEMdgbE7T3BUE" Name="Input" Kind="InputPin" />
-            <Pin Id="TedobqiliRpM4SONtHFPzj" Name="Value" Kind="InputPin" />
             <Pin Id="KyRZQQ2RqqaODo83JqmeEK" Name="Index" Kind="InputPin" DefaultValue="0" />
+            <Pin Id="TedobqiliRpM4SONtHFPzj" Name="Value" Kind="InputPin" />
             <Pin Id="NWPKZElcc0MLu9BXoE50xw" Name="Apply" Kind="InputPin" />
             <Pin Id="TSsAkqspzukMjCKWixLm0Z" Name="Output" Kind="OutputPin" />
           </Node>
@@ -797,7 +796,7 @@
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="1460,1550,52,19" Id="SHEPiG3wdjqL4ApuR23t7k">
+          <Node Bounds="1460,1595,52,19" Id="SHEPiG3wdjqL4ApuR23t7k">
             <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
@@ -810,7 +809,7 @@
           </Node>
           <Pad Id="C3GBwGHTaVxN8RxWkywksu" Comment="" Bounds="1462,1653,190,132" ShowValueBox="true" isIOBox="true" />
           <ControlPoint Id="H9gsTH0jhbyNPizNaHgwCT" Bounds="1398,1407" />
-          <Node Bounds="1537,1459,45,19" Id="P2VfnEc2xPMPztxbRah6Hk">
+          <Node Bounds="1537,1504,45,19" Id="P2VfnEc2xPMPztxbRah6Hk">
             <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LFO" />
@@ -822,8 +821,8 @@
             <Pin Id="GKMjv01Z7MyOR9gsSu7yck" Name="On New Cycle" Kind="OutputPin" />
             <Pin Id="FWgexiDwPq0MH90FxWHf0V" Name="Cycles" Kind="OutputPin" />
           </Node>
-          <Pad Id="Pk3sSv50Z24Mdw9piE8erg" Comment="" Bounds="1509,1526,35,15" ShowValueBox="true" isIOBox="true" />
-          <Node Bounds="1577,1488,39,19" Id="TnIVQ2DfpLEMqwzbrd3DlS">
+          <Pad Id="Pk3sSv50Z24Mdw9piE8erg" Comment="" Bounds="1509,1571,35,15" ShowValueBox="true" isIOBox="true" />
+          <Node Bounds="1577,1533,39,19" Id="TnIVQ2DfpLEMqwzbrd3DlS">
             <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="MOD" />
@@ -839,6 +838,15 @@
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
               <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Bang</p:buttonmode>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="Cl5GFlKZ0hCOEa7Rr7Wp99" Bounds="1543,1458,181,19" ShowValueBox="true" isIOBox="true" Value="&lt;- Apply is an optional pin">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
         </Canvas>
@@ -939,6 +947,6 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0696-g73767f5671" />
+  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0735-ge3039d4101" />
   <DocumentDependency Id="RRxCwek5VyaMuspvq1vIBA" Location="../vl/VL.Addons.Stride.vl" />
 </Document>

--- a/help/Explanation Overview of available TextureArray Nodes.vl
+++ b/help/Explanation Overview of available TextureArray Nodes.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="MWrdDmleRRAMuy7FvGSdi0" LanguageVersion="2022.5.0-0485-8f46e4a34a" Version="0.128">
-  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0485-g8f46e4a34a" />
+<Document xmlns:p="property" Id="MWrdDmleRRAMuy7FvGSdi0" LanguageVersion="2022.5.0-0696-g73767f5671" Version="0.128">
+  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0696-g73767f5671" />
   <Patch Id="S25Gr1WMWcMQSRiHRWO4uq">
     <Canvas Id="GH8DZEWEW7hN2B8H0Xzxf8" DefaultCategory="Stride" CanvasType="FullCategory" />
     <!--
@@ -17,14 +17,14 @@
         <Canvas Id="SEGevHNIoA4NfVQPE4QTGK" CanvasType="Group">
           <Pad Id="AipwsZsWZ1fLkeZHdMomDI" Comment="" Bounds="1554,2514,220,220" ShowValueBox="true" isIOBox="true" />
           <Node Bounds="294,105,87,19" Id="GJhV14MaQqoPzhRyDNVlTq">
-            <p:NodeReference LastCategoryFullName="System.Application" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="System.Application" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ApplicationPath" />
             </p:NodeReference>
             <Pin Id="EnKNcb2wa1LL6rcVcsJyVi" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="294,178,95,19" Id="LuMIcRdPHH8PCAr9yzLdWt">
-            <p:NodeReference LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="MakePath" />
             </p:NodeReference>
@@ -33,12 +33,12 @@
             <Pin Id="C3mIZrXgCUTNnPLevKgQJh" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="B3f7nZ6RfnlMGYRRqZqhxJ" Comment="" Bounds="386,146,119,15" ShowValueBox="true" isIOBox="true" Value="..\resources\textures">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="294,272,85,19" Id="IXi3mDo3XvjMkOBYXYz4eN">
-            <p:NodeReference LastCategoryFullName="IO.Path" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Dir" />
             </p:NodeReference>
@@ -50,7 +50,7 @@
             <Pin Id="EflrQlM96n9M33lNeGMFQV" Name="Files" Kind="OutputPin" />
           </Node>
           <Node Bounds="374,206,57,19" Id="EpWK7SuCgjBMD4sUatGwwI">
-            <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Changed" />
             </p:NodeReference>
@@ -59,7 +59,7 @@
             <Pin Id="AxOn6Ug0wjyNFolAYX2wI5" Name="Unchanged" Kind="OutputPin" />
           </Node>
           <Node Bounds="374,235,71,19" Id="VZeNKRP5KdQOZtTB0ptOH1">
-            <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="OR" />
             </p:NodeReference>
@@ -68,7 +68,7 @@
             <Pin Id="Vq9ZJCvW6K2O9HSXW90bpl" Name="Output" Kind="StateOutputPin" />
           </Node>
           <Pad Id="Lw3Oj6qN5K7N54qLO6GtXv" Comment="" Bounds="442,209,35,26" ShowValueBox="true" isIOBox="true" Value="False">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <CategoryReference Kind="Category" Name="Primitive" />
             </p:TypeAnnotation>
@@ -77,7 +77,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Node Bounds="236,990,49,19" Id="PKuYn4nvrYULVo1CczUJJS">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Sample (Vector4)" />
             </p:NodeReference>
@@ -86,7 +86,7 @@
             <Pin Id="EEo1YX3D1nJNOHbDWleoW4" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="236,624,60,19" Id="OlXgQhUujpgQaebiwjsuhD">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="FromFiles" />
             </p:NodeReference>
@@ -97,12 +97,12 @@
             <Pin Id="VxmfFpcxoT7QcWMsNejIdY" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="SMWflJ9d8shLi1QKuZ4SER" Comment="Load As SRGB" Bounds="266,583,35,31" ShowValueBox="true" isIOBox="true" Value="True">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Boolean" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="UCWpa9i6LODPEO0oO5ys1n" Bounds="263,509,214,69" ShowValueBox="true" isIOBox="true" Value="If  the File is already SRGB like a BC7_unorm_SRGB dds the option is ignogred">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -111,7 +111,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Node Bounds="1190,639,80,19" Id="MCc5YYckPxMLunQgLxXHWi">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="FromTextures (Async)" />
             </p:NodeReference>
@@ -122,7 +122,7 @@
             <Pin Id="Fb30WU9gGzHQRCAHvBysFC" Name="On Data" Kind="OutputPin" />
           </Node>
           <Node Bounds="575,624,80,19" Id="FpbTIwnkSZnMhpRmMqxxyf">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="FromTextures" />
             </p:NodeReference>
@@ -132,7 +132,7 @@
             <Pin Id="OLrsyWoktzfNkXdhW3VJ9F" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="QlIth9z2NeyNccailcpO7G" Bounds="21,631,203,116" ShowValueBox="true" isIOBox="true" Value="Blocking (async doesn't work). Afaik all the &quot;packing&quot; happens on  the CPU.&#xD;&#xA;&#xD;&#xA;If the image files don't contain mips, none are created.">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -141,7 +141,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="HV9RSIVsNyOK9tbmofv4TC" Bounds="661,633,263,75" ShowValueBox="true" isIOBox="true" Value="Uses GraphicsContext.CommandList.CopyRegion&#xD;&#xA;Afaik Everything is done on  the GPU.">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -150,7 +150,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="EGXtyWxRSuRQC9KnRUEQoh" Bounds="1278,636,233,78" ShowValueBox="true" isIOBox="true" Value="Same wrapped in an AsyncTask.&#xD;&#xA;Not sure about that one, uses some&#xD;&#xA;dodgy logic to dispose of the TextureArray.">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -160,7 +160,7 @@
           </Pad>
           <ControlPoint Id="AjChJTh4AGmO4Br6So6H5Q" Bounds="237,380" />
           <Node Bounds="638,348,129,100" Id="SkbZzDyGmxHOUNwpGg7Pbn">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <CategoryReference Kind="Category" Name="Primitive" />
               <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -171,7 +171,7 @@
               <Patch Id="RcZhvSiJS2NQAT9W0gtOOF" Name="Update" ManuallySortedPins="true" />
               <Patch Id="QbPfrDrxh4mQS7Blvk0eKr" Name="Dispose" ManuallySortedPins="true" />
               <Node Bounds="650,408,105,19" Id="H1NTPvSS4i7NBewYfr271w">
-                <p:NodeReference LastCategoryFullName="Stride.Assets" LastSymbolSource="VL.Stride.Assets.Windows.vl" LastDependency="VL.Stride.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Assets" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="FileTexture" />
                 </p:NodeReference>
@@ -191,7 +191,7 @@
             <ControlPoint Id="H2sZzNgkxlUQHrkjZXtgWJ" Bounds="652,442" Alignment="Bottom" />
           </Node>
           <Node Bounds="700,477,50,26" Id="PbvMCScQcRzLUNzscrNM9c">
-            <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="OR (Spectral)" />
             </p:NodeReference>
@@ -199,7 +199,7 @@
             <Pin Id="NjCOSTI2FJONJEZ2qXKgEw" Name="Result" Kind="OutputPin" />
           </Node>
           <Node Bounds="700,524,56,19" Id="LXWwf6r7QXlPrw4x3dsxxP">
-            <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="TogEdge" />
             </p:NodeReference>
@@ -210,7 +210,7 @@
           <Pad Id="SmAVrgzxBJqNPmQeCsXwqA" Comment="" Bounds="238,753,190,132" ShowValueBox="true" isIOBox="true" />
           <Pad Id="Q0BtounHsbRM2PoRmWEGw3" Comment="" Bounds="577,750,190,132" ShowValueBox="true" isIOBox="true" />
           <Pad Id="TShQ77agmwWMk7pLDZrzqn" Bounds="339,632,199,66" ShowValueBox="true" isIOBox="true" Value="All images / textures have to have the same properties like dimensions, format, mips">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -219,7 +219,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Node Bounds="0,1826,454,19" Id="Lni7P27fLQAOTaIKkTthqX">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="RootScene" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -232,12 +232,12 @@
             <Pin Id="HoaHTVqEymwL8Cwog9ldzj" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="-40,1886,245,19" Id="EJc18nKLKFANHdPO0qKzfy">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
             <Pin Id="SX2MoreQTg3OxmBcoNQjNb" Name="Bounds" Kind="InputPin" DefaultValue="1457, 111, 786, 432">
-              <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>
             </Pin>
@@ -258,7 +258,7 @@
             <Pin Id="Fc2a3t934ExMlvJXhZuwDs" Name="Input Source" Kind="OutputPin" />
           </Node>
           <Node Bounds="20,1855,285,19" Id="FhTg7iCrJ9bMuXeRaNyUqd">
-            <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="OrbitCamera" />
             </p:NodeReference>
@@ -266,12 +266,12 @@
             <Pin Id="GCMDVpfblxWPVHuNunScKy" Name="Children" Kind="InputPin" />
             <Pin Id="E6KNsVkSqQ3Pt2sTnMSzvh" Name="Initial Interest" Kind="InputPin" />
             <Pin Id="Q6mpPhdUWCiL42PMNaALGD" Name="Initial Yaw" Kind="InputPin" DefaultValue="0.49">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="PmRwa6z17z9PzbSQXhJbvD" Name="Initial Pitch" Kind="InputPin" DefaultValue="0">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -292,20 +292,20 @@
             <Pin Id="BzYRcOc8ugtM7wPjG5OPvH" Name="Camera Component" Kind="OutputPin" />
           </Node>
           <Node Bounds="497,1298,91,114" Id="BZJcjQc8v5hNsJPDmHF5LF">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
               <CategoryReference Kind="Category" Name="Primitive" />
             </p:NodeReference>
             <Pin Id="DZNozQmQEr0LxVNNuGAUTi" Name="Break" Kind="OutputPin" />
             <ControlPoint Id="FKITqBRW9dLOriAxdPLqW5" Bounds="511,1406" Alignment="Bottom" />
-            <ControlPoint Id="HPMl8gjr91nLtgOFmTZlaB" Bounds="511,1305" Alignment="Top" />
+            <ControlPoint Id="HPMl8gjr91nLtgOFmTZlaB" Bounds="511,1304" Alignment="Top" />
             <Patch Id="PltItEzwlNaQGw87CNMzEK" ManuallySortedPins="true">
               <Patch Id="Neeoiz2HyyjOhS2vGIXQ4z" Name="Create" ManuallySortedPins="true" />
               <Patch Id="NDUxEUwG7jON0yncaJnkRu" Name="Update" ManuallySortedPins="true" />
               <Patch Id="TedGd5lLfwOMRlubzp6wCH" Name="Dispose" ManuallySortedPins="true" />
               <Node Bounds="509,1353,67,19" Id="AXEe3kLcHAgNkQJY0mQeCE">
-                <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Translation" />
                 </p:NodeReference>
@@ -313,7 +313,7 @@
                 <Pin Id="Cl7LgGdGsNMMwc1gxNvdhA" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="509,1322,46,19" Id="KzCVSXAXqubPpK537UUOQ0">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -326,12 +326,12 @@
             </Patch>
           </Node>
           <Pad Id="VpJG62fTLtePA5Niqwvuku" Comment="Count" Bounds="591,1231,20,15" ShowValueBox="true" isIOBox="true" Value="4">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="136,1430,76,19" Id="Gbh1Cc0Wua7LicS8NzIQ1t">
-            <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="UniformScale" />
               <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -343,12 +343,12 @@
             <Pin Id="CXTwqcMpWe2NfAvIPPT3Vy" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="HPewaF6YNJtNEIgRWppPPG" Comment="Scaling" Bounds="209,1411,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="509,1468,65,19" Id="JEySFO6nHqUN1mlzWonGWz">
-            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="FromValue" />
               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -357,19 +357,19 @@
             <Pin Id="LD4EC04yssHQaHYOMuhrtv" Name="Result" Kind="OutputPin" />
           </Node>
           <Node Bounds="225,1737,185,19" Id="Lg0gMz2GhpMMc6aswapQOH">
-            <p:NodeReference LastCategoryFullName="Stride.Lights" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="DirectionalLight" />
             </p:NodeReference>
             <Pin Id="QE2K40jmiFEOlwVDGDSptm" Name="Position" Kind="InputPin" DefaultValue="0.98, 1.7, -0.64">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="NGNQ4Uu7U3ZLUM5F5pBVXH" Name="Target" Kind="InputPin" />
             <Pin Id="HRnTdiy95n6NiKRhF6qwyz" Name="Color" Kind="InputPin" />
             <Pin Id="NcIoNPioRXsNXWsDMieSDO" Name="Intensity" Kind="InputPin" DefaultValue="2.97">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -382,7 +382,7 @@
             <Pin Id="C6E2VlkYZLcLOBp2uTCdO3" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="337,1776,205,19" Id="Ko9JtQOuifRMw9uVCxTKZW">
-            <p:NodeReference LastCategoryFullName="Stride.Lights" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SkyboxLight" />
             </p:NodeReference>
@@ -390,7 +390,7 @@
             <Pin Id="ENg4sjeRk4xLUS4sPsZTjA" Name="Cube Map" Kind="InputPin" />
             <Pin Id="PbmcAqe9BjVQHgXGtuLjU9" Name="Is Specular Only" Kind="InputPin" />
             <Pin Id="AKA1lopgvVpN1t94BDwIva" Name="Intensity" Kind="InputPin" DefaultValue="0.15">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -404,7 +404,7 @@
             <Pin Id="HhyqkFbeqfDN6nhChpfcsr" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="236,1350,225,19" Id="Eb9NFngbZPzP0jCNpofKxF">
-            <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Materials" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="PBRMaterial (Metallic)" />
             </p:NodeReference>
@@ -423,27 +423,27 @@
             <Pin Id="AmiD0eB8O6RLvn1Mp3k3Ij" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="509,1250,85,19" Id="VOGvpAX65c3LxL1jeUgCd5">
-            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LinearSpread" />
             </p:NodeReference>
             <Pin Id="JED87vJx7OUN1hdzGHFOr0" Name="Center" Kind="InputPin" DefaultValue="2" />
             <Pin Id="BcoVZiZjUMZMsoleECKeay" Name="Width" Kind="InputPin" DefaultValue="100">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="KDibFPS2mejL71QShq6EfU" Name="Alignment" Kind="InputPin" />
             <Pin Id="HcJjEND5NsnNJTzN98Hyo8" Name="Phase" Kind="InputPin" />
             <Pin Id="JPKHmHPxcNtNvoQtEZMO8m" Name="Count" Kind="InputPin" DefaultValue="7">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="IBkexNi8KRbMG3bSNYE0Tx" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="509,1426,147,19" Id="D9a8jQigVQwMHeKXiO1JDS">
-            <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="InstancingSpreadComponent" />
             </p:NodeReference>
@@ -454,17 +454,17 @@
             <Pin Id="H1UdSJ50SlzLXre6cL1mV2" Name="Component" Kind="OutputPin" />
           </Node>
           <Pad Id="VU4llJuO7ywL2dpBOQitfe" Comment="Roughness" Bounds="278,1313,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="GViYVOkKa7iQIShQ6QfgN2" Comment="Metalness" Bounds="258,1289,35,15" ShowValueBox="true" isIOBox="true" Value="0.5">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="136,1496,205,19" Id="HrJVlSMbKLSLJUkwzPl8jY">
-            <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Plane" />
             </p:NodeReference>
@@ -482,7 +482,7 @@
             <Pin Id="N4rjtYyYF19LMl1veHG71u" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="1048,1301,91,114" Id="BwYzdbx0VApPn8dwQnir9X">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
               <CategoryReference Kind="Category" Name="Primitive" />
@@ -495,7 +495,7 @@
               <Patch Id="AZaAhlaST27N2omaOkGmoC" Name="Update" ManuallySortedPins="true" />
               <Patch Id="TkfN6uLji5aQYbOdTL7N8Y" Name="Dispose" ManuallySortedPins="true" />
               <Node Bounds="1060,1356,67,19" Id="G1otxEs0cjAPeXglTp77Fc">
-                <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Translation" />
                 </p:NodeReference>
@@ -503,7 +503,7 @@
                 <Pin Id="MDkMdIHddlZMYLwnZBhbJ9" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="1060,1325,46,19" Id="VmO7gDNDhUXPcPkn3h3gXO">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -516,12 +516,12 @@
             </Patch>
           </Node>
           <Pad Id="Avpaq6kgT3kPfo9xo36GAO" Comment="Count" Bounds="1142,1234,20,15" ShowValueBox="true" isIOBox="true" Value="4">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="687,1433,76,19" Id="Sil5j3febvaLI1xR5oAAMf">
-            <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="UniformScale" />
               <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -533,12 +533,12 @@
             <Pin Id="UkFMe8NVePELmWzuwObUFP" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="EviRBdeoBKXLHZL6bxYqMR" Comment="Scaling" Bounds="760,1414,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="1060,1471,65,19" Id="If4CNm2FfVDL7samB4dzG7">
-            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="FromValue" />
               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -547,7 +547,7 @@
             <Pin Id="Hr3wnZbfUr0NmxlwdGZCeR" Name="Result" Kind="OutputPin" />
           </Node>
           <Node Bounds="787,1353,225,19" Id="HBwvXSVhUsBM6hJlSv29dg">
-            <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Materials" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="PBRMaterial (Metallic)" />
             </p:NodeReference>
@@ -566,27 +566,27 @@
             <Pin Id="HtG9NNU1MSHMjlpj8VuE4G" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="1060,1253,85,19" Id="NEGPjVAL0NDQGysyxylf7x">
-            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LinearSpread" />
             </p:NodeReference>
             <Pin Id="GKSxkDqkfEtMr4VsbXkJ6F" Name="Center" Kind="InputPin" DefaultValue="2" />
             <Pin Id="FwINEY9oxKKOQU7QVX7piP" Name="Width" Kind="InputPin" DefaultValue="100">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="Gi9FPYeIWZEO0NVFTYgcyx" Name="Alignment" Kind="InputPin" />
             <Pin Id="BS2cVyOXFAFNti4gTGAvkF" Name="Phase" Kind="InputPin" />
             <Pin Id="B8qTHz6xvz7P5SdItbgSjG" Name="Count" Kind="InputPin" DefaultValue="7">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="KK2s35x62SuMfzW7uQ190d" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="1060,1429,147,19" Id="CKhyPXnSvPrPtzULedri8X">
-            <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="InstancingSpreadComponent" />
             </p:NodeReference>
@@ -597,17 +597,17 @@
             <Pin Id="DUNodlWkkP7PXT3kHsw4UH" Name="Component" Kind="OutputPin" />
           </Node>
           <Pad Id="TA8XHjfB3wLPbaCG65bGRX" Comment="Roughness" Bounds="829,1316,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="BX18rhxhtDtOWH8y1yHdNV" Comment="Metalness" Bounds="809,1292,35,15" ShowValueBox="true" isIOBox="true" Value="0.5">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="687,1499,205,19" Id="JmUWqnBCopUNVfThj3R4Jm">
-            <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Plane" />
             </p:NodeReference>
@@ -625,7 +625,7 @@
             <Pin Id="DKU66ytrrceMCecM87thGp" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="114,1648,85,19" Id="Mg8XuHVYGjKNi50udf1wCT">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
               <Choice Kind="ProcessAppFlag" Name="Group" />
@@ -638,7 +638,7 @@
             <Pin Id="VkIPUpAfb7oMDD8wSKgFI4" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="788,1001,49,19" Id="U73wCVW4shTL5M8f9yyiNq">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Sample (Vector4 WithIndex)" />
             </p:NodeReference>
@@ -648,10 +648,10 @@
             <Pin Id="H7m2w7h4g9OQKDgPlITHuh" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="Nsb5VxMNYckN32GB9bmYLG" Comment="Indices" Bounds="954,756,30,141" ShowValueBox="true" isIOBox="true" Value="1, 0, 3, 2">
-            <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+            <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.Collections.vl">
               <Choice Kind="TypeFlag" Name="Spread" />
               <p:TypeArguments>
-                <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </TypeReference>
               </p:TypeArguments>
@@ -661,7 +661,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Node Bounds="952,902,57,19" Id="OVTIgz0YU1ELfAJIIP2nvG">
-            <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+            <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Changed" />
             </p:NodeReference>
@@ -670,7 +670,7 @@
             <Pin Id="I7OQlFIbrFaMDsV9zBiJxz" Name="Unchanged" Kind="OutputPin" />
           </Node>
           <Node Bounds="832,931,125,19" Id="PhxreQIzFVuO6LnlMVmwe1">
-            <p:NodeReference LastCategoryFullName="Stride.Buffers" LastSymbolSource="VL.Stride.Graphics.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.Graphics.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
             </p:NodeReference>
@@ -685,10 +685,10 @@
             <Pin Id="DghxU4iRf4kPTynjPASE0o" Name="Has Changed" Kind="OutputPin" />
           </Node>
           <Node Bounds="1190,828,52,19" Id="SGglwFSgrGgPJ0AFuQpBgj">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
-              <Choice Kind="ProcessAppFlag" Name="GetSlice" />
+              <Choice Kind="ProcessAppFlag" Name="GetItem" />
             </p:NodeReference>
             <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">Low</p:HelpFocus>
             <Pin Id="IW08d7aOVDxOIgxRQ4h7d1" Name="Input" Kind="InputPin" />
@@ -696,13 +696,13 @@
             <Pin Id="SvHJvBa3jTfOpgUrcV6C8t" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="VNuCquE4rJzN8mXFw1tXiv" Comment="Index" Bounds="1239,810,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="TPZCg6pZxACNecm7iicL7V" Comment="" Bounds="1192,883,190,132" ShowValueBox="true" isIOBox="true" />
           <Node Bounds="1383,1084,65,19" Id="TxOPpU4SZwVQGQUVUy0sS5">
-            <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="IsAssigned" />
             </p:NodeReference>
@@ -711,7 +711,7 @@
             <Pin Id="D45OkLtRId9LmyupWtu5dC" Name="Not Assigned" Kind="OutputPin" />
           </Node>
           <Node Bounds="1383,1122,112,85" Id="FgueLoljtnoPGv3xa4QqX4">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <CategoryReference Kind="Category" Name="Primitive" />
               <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -721,7 +721,7 @@
               <Patch Id="Aodcu11ntfbQZVGUAUPf4H" Name="Create" ManuallySortedPins="true" />
               <Patch Id="GfUc6mcTmPoORgZNeZnc27" Name="Then" ManuallySortedPins="true" />
               <Node Bounds="1395,1150,68,26" Id="NOq4OZOfgWzPnPrnWYq1RR">
-                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
+                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Description" />
                   <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
@@ -741,7 +741,7 @@
             <ControlPoint Id="Kq8dkBzCs2LLpOkLLvv80d" Bounds="1458,1128" Name="Desc" Alignment="Top" />
           </Node>
           <Node Bounds="1459,1356,78,19" Id="N1hDToDTw8hLScTyjogneM">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="New2DArray" />
             </p:NodeReference>
@@ -753,24 +753,25 @@
             <Pin Id="LGqqsV6wOOwNFuczZUv7Vy" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="SUSv6XeLX2rMcSKEvQToVP" Comment="SIze" Bounds="1461,1304,35,28" ShowValueBox="true" isIOBox="true" Value="512, 512">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Int2" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="1460,1451,51,19" Id="VrUIAxIatc2PS2wEPGYDss">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+          <Node Bounds="1460,1451,65,19" Id="VrUIAxIatc2PS2wEPGYDss">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="SetSlice" />
+              <Choice Kind="ProcessAppFlag" Name="SetItem" />
               <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
             </p:NodeReference>
             <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">Low</p:HelpFocus>
             <Pin Id="IWbOBFYlwXEMdgbE7T3BUE" Name="Input" Kind="InputPin" />
             <Pin Id="TedobqiliRpM4SONtHFPzj" Name="Value" Kind="InputPin" />
             <Pin Id="KyRZQQ2RqqaODo83JqmeEK" Name="Index" Kind="InputPin" DefaultValue="0" />
+            <Pin Id="NWPKZElcc0MLu9BXoE50xw" Name="Apply" Kind="InputPin" />
             <Pin Id="TSsAkqspzukMjCKWixLm0Z" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="1459,1254,176,19" Id="VNeK1adnkZSNTOYIui4YPG">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="TextureDescription" />
               <Choice Kind="OperationCallFlag" Name="Split" />
@@ -786,21 +787,21 @@
             <Pin Id="QQplMImr7LnM141JkGdO83" Name="Array Size" Kind="OutputPin" />
             <Pin Id="CzhuknhE6qmLCVJMbDDa0V" Name="Usage" Kind="OutputPin" />
           </Node>
-          <Pad Id="AUpetYmHFgHPuLllEg9ICG" Comment="Index" Bounds="1508,1426,35,15" ShowValueBox="true" isIOBox="true" Value="0">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+          <Pad Id="AUpetYmHFgHPuLllEg9ICG" Comment="Index" Bounds="1502,1409,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="Eq2OxJAtKecOvom7Bjaa4E" Comment="Array Size" Bounds="1548,1312,35,15" ShowValueBox="true" isIOBox="true" Value="2">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="1460,1550,52,19" Id="SHEPiG3wdjqL4ApuR23t7k">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
-              <Choice Kind="ProcessAppFlag" Name="GetSlice" />
+              <Choice Kind="ProcessAppFlag" Name="GetItem" />
             </p:NodeReference>
             <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">Low</p:HelpFocus>
             <Pin Id="LRZWbtR3VexPtOZAlWqGJN" Name="Input" Kind="InputPin" />
@@ -810,7 +811,7 @@
           <Pad Id="C3GBwGHTaVxN8RxWkywksu" Comment="" Bounds="1462,1653,190,132" ShowValueBox="true" isIOBox="true" />
           <ControlPoint Id="H9gsTH0jhbyNPizNaHgwCT" Bounds="1398,1407" />
           <Node Bounds="1537,1459,45,19" Id="P2VfnEc2xPMPztxbRah6Hk">
-            <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LFO" />
             </p:NodeReference>
@@ -823,7 +824,7 @@
           </Node>
           <Pad Id="Pk3sSv50Z24Mdw9piE8erg" Comment="" Bounds="1509,1526,35,15" ShowValueBox="true" isIOBox="true" />
           <Node Bounds="1577,1488,39,19" Id="TnIVQ2DfpLEMqwzbrd3DlS">
-            <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="MOD" />
             </p:NodeReference>
@@ -831,6 +832,15 @@
             <Pin Id="JiZ2JwK1lOQOpLnTCUd4ab" Name="Input 2" Kind="InputPin" DefaultValue="2" />
             <Pin Id="S8ia9BgPyDhPA1wAm9b7ig" Name="Output" Kind="OutputPin" />
           </Node>
+          <Pad Id="QGfedFX3g7pLOiO1Ms7V9k" Comment="Apply" Bounds="1594,1407,35,35" ShowValueBox="true" isIOBox="true" Value="False">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
+              <CategoryReference Kind="Category" Name="Primitive" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Bang</p:buttonmode>
+            </p:ValueBoxSettings>
+          </Pad>
         </Canvas>
         <Patch Id="KEPLpmhjLZVQIRA1UCbCCx" Name="Create" />
         <Patch Id="A0Eu5QHBEa9NRnFPP1qryh" Name="Update" />
@@ -925,9 +935,10 @@
         <Link Id="JhSaxCYt9JPLE4ejrjBf5N" Ids="FWgexiDwPq0MH90FxWHf0V,AJZmY9XpXSIOkSeBu2fF0H" />
         <Link Id="FyKPZWtU1ugLBH6vPbqL0M" Ids="S8ia9BgPyDhPA1wAm9b7ig,Pk3sSv50Z24Mdw9piE8erg" />
         <Link Id="HEqkyZkXQdaLkhTpTxKNSw" Ids="Pk3sSv50Z24Mdw9piE8erg,NRwvQOfMpzBNjzp1TNdTQW" />
+        <Link Id="UbP7LM8kCL2NZKHenirIKS" Ids="QGfedFX3g7pLOiO1Ms7V9k,NWPKZElcc0MLu9BXoE50xw" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0485-g8f46e4a34a" />
+  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0696-g73767f5671" />
   <DocumentDependency Id="RRxCwek5VyaMuspvq1vIBA" Location="../vl/VL.Addons.Stride.vl" />
 </Document>

--- a/help/HowTo Use GetItem(TextureArray).vl
+++ b/help/HowTo Use GetItem(TextureArray).vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="MWrdDmleRRAMuy7FvGSdi0" LanguageVersion="2022.5.0-0485-8f46e4a34a" Version="0.128">
-  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0485-g8f46e4a34a" />
+<Document xmlns:p="property" Id="E0s6fiLtmH6OOuPBBARx7Z" LanguageVersion="2022.5.0-0696-g73767f5671" Version="0.128">
+  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0696-g73767f5671" />
   <Patch Id="S25Gr1WMWcMQSRiHRWO4uq">
     <Canvas Id="GH8DZEWEW7hN2B8H0Xzxf8" DefaultCategory="Stride" CanvasType="FullCategory" />
     <!--
@@ -17,7 +17,7 @@
         <Canvas Id="SEGevHNIoA4NfVQPE4QTGK" CanvasType="Group">
           <Pad Id="AipwsZsWZ1fLkeZHdMomDI" Comment="" Bounds="1688,2488,220,220" ShowValueBox="true" isIOBox="true" />
           <Node Bounds="159,887,454,19" Id="LvGf2HrRClFN95XCRNJfDv">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="RootScene" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -30,12 +30,12 @@
             <Pin Id="KHva6AZKfMqL4prF8RcLaN" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="119,947,245,19" Id="QyweS2Sn288PWlnPcK4Vnt">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
             <Pin Id="OImhO4Ia1oQP3zVjIONPVr" Name="Bounds" Kind="InputPin" DefaultValue="1429, 83, 786, 432">
-              <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>
             </Pin>
@@ -56,7 +56,7 @@
             <Pin Id="IbKQhILNZaOLxS7iiSIzNR" Name="Input Source" Kind="OutputPin" />
           </Node>
           <Node Bounds="179,916,285,19" Id="HppIYi7F7ldON0fF5xw5Z5">
-            <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="OrbitCamera" />
             </p:NodeReference>
@@ -64,12 +64,12 @@
             <Pin Id="Hg6p4qX6go2Lc3Axvu3fNE" Name="Children" Kind="InputPin" />
             <Pin Id="DoNV65S8LELQRZRob0Vi6z" Name="Initial Interest" Kind="InputPin" />
             <Pin Id="KiBoMbLMu4VM8r5YVovVVd" Name="Initial Yaw" Kind="InputPin" DefaultValue="0.49">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="ObycETGyy14PU3jKhjMAso" Name="Initial Pitch" Kind="InputPin" DefaultValue="0">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -90,20 +90,20 @@
             <Pin Id="D3lXgH5PiAINLJh2g4jXek" Name="Camera Component" Kind="OutputPin" />
           </Node>
           <Node Bounds="634,567,91,120" Id="SBHyiUQ6MkxLttdXF1lpcg">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
               <CategoryReference Kind="Category" Name="Primitive" />
             </p:NodeReference>
             <Pin Id="GcXs9eZ9qzdMHawwR2zp1m" Name="Break" Kind="OutputPin" />
-            <ControlPoint Id="HueR1iQOdLZOh0r4KmPSdk" Bounds="648,669" Alignment="Bottom" />
-            <ControlPoint Id="DqapW1oSGcfN4fBJNGqbn1" Bounds="648,588" Alignment="Top" />
+            <ControlPoint Id="HueR1iQOdLZOh0r4KmPSdk" Bounds="648,681" Alignment="Bottom" />
+            <ControlPoint Id="DqapW1oSGcfN4fBJNGqbn1" Bounds="648,573" Alignment="Top" />
             <Patch Id="BP4QS8HaipzNP369KAOlox" ManuallySortedPins="true">
               <Patch Id="Pga8YBwllxgPcGuLooXwhl" Name="Create" ManuallySortedPins="true" />
               <Patch Id="ObnGmjjjcTMOizCjSjMCNc" Name="Update" ManuallySortedPins="true" />
               <Patch Id="AwXjxe5UWUhOuY5ohn5NFa" Name="Dispose" ManuallySortedPins="true" />
               <Node Bounds="646,590,46,19" Id="F0bZGc5O45ANfhjftW20rS">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -114,7 +114,7 @@
                 <Pin Id="GMUIs6R893VNYe7SgiiYwA" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="646,624,67,19" Id="OGotIOv0UUPQLEKutJ7qDc">
-                <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Translation" />
                 </p:NodeReference>
@@ -124,12 +124,12 @@
             </Patch>
           </Node>
           <Pad Id="IoAIxXXZNdHL1BWyyHdWxq" Comment="Count" Bounds="728,512,20,15" ShowValueBox="true" isIOBox="true" Value="2">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="273,710,76,19" Id="FyIEBQiTQJTMziJu3dzWQg">
-            <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="UniformScale" />
               <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -141,12 +141,12 @@
             <Pin Id="RUieguJYj8eMVapCMlz9M4" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="Bpf9WbTWAhqMuGPGNmQhHa" Comment="Scaling" Bounds="346,691,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="646,731,65,19" Id="CTLSSCQU5obOy5WsuFUXDR">
-            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="FromValue" />
               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -155,19 +155,19 @@
             <Pin Id="UMvglgwE5V1LBW9meDW2ia" Name="Result" Kind="OutputPin" />
           </Node>
           <Node Bounds="383,806,185,19" Id="UcYNPvP2gp3NECwEzL4jMo">
-            <p:NodeReference LastCategoryFullName="Stride.Lights" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="DirectionalLight" />
             </p:NodeReference>
             <Pin Id="MB5S5tQBrIUP6V0SfTlFl9" Name="Position" Kind="InputPin" DefaultValue="0.98, 1.7, -0.64">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="ULDmES2tglZLoFJwQXCHmT" Name="Target" Kind="InputPin" />
             <Pin Id="HJvoWBNe8U7Orbs76FAz0j" Name="Color" Kind="InputPin" />
             <Pin Id="J96VNKbAozlMgI0suvVKDb" Name="Intensity" Kind="InputPin" DefaultValue="2.97">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -180,7 +180,7 @@
             <Pin Id="REGURjqM1FiOeHD0NiqmLz" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="496,837,205,19" Id="HYDa6X0B2KxNUs23dFpDCp">
-            <p:NodeReference LastCategoryFullName="Stride.Lights" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SkyboxLight" />
             </p:NodeReference>
@@ -188,7 +188,7 @@
             <Pin Id="RqoqszxnrhoOgDp9oteH1a" Name="Cube Map" Kind="InputPin" />
             <Pin Id="QwEZnuG9agiPwLEQUZeNJr" Name="Is Specular Only" Kind="InputPin" />
             <Pin Id="HOfCavGAaotMPKAuKiK6od" Name="Intensity" Kind="InputPin" DefaultValue="0.15">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -202,7 +202,7 @@
             <Pin Id="CBXHknyx92AQFfd83bzyL3" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="340,604,225,19" Id="SZer0JHZNxzMn24u8jCMJJ">
-            <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Materials" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="PBRMaterial (Metallic)" />
             </p:NodeReference>
@@ -221,27 +221,27 @@
             <Pin Id="KpYx7fbp3O9NaqCO8RkQKQ" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="646,531,85,19" Id="BGGx628GHmiNz7ezOGVoZd">
-            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LinearSpread" />
             </p:NodeReference>
             <Pin Id="K12PSQ4wznJMNC40piWAcX" Name="Center" Kind="InputPin" />
             <Pin Id="LFYEjbFg8fjQcdsC3N6JPR" Name="Width" Kind="InputPin" DefaultValue="5.9">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="QacMm6yr4qyO5QYRJb5Het" Name="Alignment" Kind="InputPin" />
             <Pin Id="AgjIK4rfrN6PW3U5lYNYii" Name="Phase" Kind="InputPin" />
             <Pin Id="ITZ455qMTXQNl9tYnDkBop" Name="Count" Kind="InputPin" DefaultValue="7">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="QeHsozLrKM9NbGkNd7rnDz" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="646,689,147,19" Id="NTNdMRnPH00NrOlSZOCyaD">
-            <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="InstancingSpreadComponent" />
             </p:NodeReference>
@@ -252,14 +252,14 @@
             <Pin Id="KzIWfOxMC8JLesLWOWh4n1" Name="Component" Kind="OutputPin" />
           </Node>
           <Node Bounds="395,70,87,19" Id="GJhV14MaQqoPzhRyDNVlTq">
-            <p:NodeReference LastCategoryFullName="System.Application" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="System.Application" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ApplicationPath" />
             </p:NodeReference>
             <Pin Id="EnKNcb2wa1LL6rcVcsJyVi" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="395,143,95,19" Id="LuMIcRdPHH8PCAr9yzLdWt">
-            <p:NodeReference LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="MakePath" />
             </p:NodeReference>
@@ -268,12 +268,12 @@
             <Pin Id="C3mIZrXgCUTNnPLevKgQJh" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="B3f7nZ6RfnlMGYRRqZqhxJ" Comment="" Bounds="487,111,119,15" ShowValueBox="true" isIOBox="true" Value="..\resources\textures">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="395,237,85,19" Id="IXi3mDo3XvjMkOBYXYz4eN">
-            <p:NodeReference LastCategoryFullName="IO.Path" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Dir" />
             </p:NodeReference>
@@ -285,7 +285,7 @@
             <Pin Id="EflrQlM96n9M33lNeGMFQV" Name="Files" Kind="OutputPin" />
           </Node>
           <Node Bounds="475,171,57,19" Id="EpWK7SuCgjBMD4sUatGwwI">
-            <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Changed" />
             </p:NodeReference>
@@ -294,7 +294,7 @@
             <Pin Id="AxOn6Ug0wjyNFolAYX2wI5" Name="Unchanged" Kind="OutputPin" />
           </Node>
           <Node Bounds="475,200,71,19" Id="VZeNKRP5KdQOZtTB0ptOH1">
-            <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="OR" />
             </p:NodeReference>
@@ -303,7 +303,7 @@
             <Pin Id="Vq9ZJCvW6K2O9HSXW90bpl" Name="Output" Kind="StateOutputPin" />
           </Node>
           <Pad Id="Lw3Oj6qN5K7N54qLO6GtXv" Comment="" Bounds="543,174,35,26" ShowValueBox="true" isIOBox="true" Value="False">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <CategoryReference Kind="Category" Name="Primitive" />
             </p:TypeAnnotation>
@@ -312,7 +312,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Node Bounds="340,346,60,19" Id="Ux5KaHsgZOcQB4arsPjmYf">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="FromFiles" />
             </p:NodeReference>
@@ -322,17 +322,17 @@
             <Pin Id="JQ1thDAzrsmPoZ2k3cmg72" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="T73SNbUq2nyN1RE2bmS2Lv" Comment="Roughness" Bounds="382,567,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="JEw2kuCxPJEL5iYwZgRkQe" Comment="Metalness" Bounds="362,543,35,15" ShowValueBox="true" isIOBox="true" Value="0.5">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="273,759,205,19" Id="LCgSg78BOXkP5wY55MsTz2">
-            <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Sphere" />
             </p:NodeReference>
@@ -349,10 +349,10 @@
             <Pin Id="CfIQ8O1LuqrNLdD5YtaoWW" Name="Normal" Kind="InputPin" DefaultValue="UpZ" />
           </Node>
           <Node Bounds="340,432,52,19" Id="Lmcl3HUjqM2NYNEPrfDIC1">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
-              <Choice Kind="ProcessAppFlag" Name="GetSlice" />
+              <Choice Kind="ProcessAppFlag" Name="GetItem" />
             </p:NodeReference>
             <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
             <Pin Id="KdqOMwE4FTaMaE2uOudWYz" Name="Input" Kind="InputPin" />
@@ -360,7 +360,7 @@
             <Pin Id="SNqNx5Aj8DbQa9GqqGXcon" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="340,495,65,19" Id="OD4ljSOnpxhMSl1Ja6Lkwl">
-            <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ColorMap" />
             </p:NodeReference>
@@ -371,7 +371,7 @@
             <Pin Id="NG0q0DJqAJzNRcuLLdSoFG" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="NzXFJSEMEkdOd8iTxwFENO" Comment="Index" Bounds="389,410,35,15" ShowValueBox="true" isIOBox="true" Value="3">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
@@ -416,6 +416,6 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0485-g8f46e4a34a" />
+  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0696-g73767f5671" />
   <DocumentDependency Id="RRxCwek5VyaMuspvq1vIBA" Location="../vl/VL.Addons.Stride.vl" />
 </Document>

--- a/help/HowTo Use SetItem(TextureArray).vl
+++ b/help/HowTo Use SetItem(TextureArray).vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="MWrdDmleRRAMuy7FvGSdi0" LanguageVersion="2022.5.0-0485-8f46e4a34a" Version="0.128">
-  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0485-g8f46e4a34a" />
+<Document xmlns:p="property" Id="Jm4K8HLevsLMUvbXpCVnn2" LanguageVersion="2022.5.0-0696-g73767f5671" Version="0.128">
+  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0696-g73767f5671" />
   <Patch Id="S25Gr1WMWcMQSRiHRWO4uq">
     <Canvas Id="GH8DZEWEW7hN2B8H0Xzxf8" DefaultCategory="Stride" CanvasType="FullCategory" />
     <!--
@@ -17,7 +17,7 @@
         <Canvas Id="SEGevHNIoA4NfVQPE4QTGK" CanvasType="Group">
           <Pad Id="AipwsZsWZ1fLkeZHdMomDI" Comment="" Bounds="1646,2490,220,220" ShowValueBox="true" isIOBox="true" />
           <Node Bounds="186,1772,454,19" Id="LvGf2HrRClFN95XCRNJfDv">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="RootScene" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -30,12 +30,12 @@
             <Pin Id="KHva6AZKfMqL4prF8RcLaN" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="146,1832,245,19" Id="QyweS2Sn288PWlnPcK4Vnt">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
-            <Pin Id="OImhO4Ia1oQP3zVjIONPVr" Name="Bounds" Kind="InputPin" DefaultValue="1429, 83, 786, 432">
-              <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <Pin Id="OImhO4Ia1oQP3zVjIONPVr" Name="Bounds" Kind="InputPin" DefaultValue="1046, 85, 786, 432">
+              <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>
             </Pin>
@@ -56,7 +56,7 @@
             <Pin Id="IbKQhILNZaOLxS7iiSIzNR" Name="Input Source" Kind="OutputPin" />
           </Node>
           <Node Bounds="206,1801,285,19" Id="HppIYi7F7ldON0fF5xw5Z5">
-            <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="OrbitCamera" />
             </p:NodeReference>
@@ -64,12 +64,12 @@
             <Pin Id="Hg6p4qX6go2Lc3Axvu3fNE" Name="Children" Kind="InputPin" />
             <Pin Id="DoNV65S8LELQRZRob0Vi6z" Name="Initial Interest" Kind="InputPin" />
             <Pin Id="KiBoMbLMu4VM8r5YVovVVd" Name="Initial Yaw" Kind="InputPin" DefaultValue="0.49">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="ObycETGyy14PU3jKhjMAso" Name="Initial Pitch" Kind="InputPin" DefaultValue="0">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -90,7 +90,7 @@
             <Pin Id="D3lXgH5PiAINLJh2g4jXek" Name="Camera Component" Kind="OutputPin" />
           </Node>
           <Node Bounds="659,1442,91,116" Id="SBHyiUQ6MkxLttdXF1lpcg">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
               <CategoryReference Kind="Category" Name="Primitive" />
@@ -103,7 +103,7 @@
               <Patch Id="ObnGmjjjcTMOizCjSjMCNc" Name="Update" ManuallySortedPins="true" />
               <Patch Id="AwXjxe5UWUhOuY5ohn5NFa" Name="Dispose" ManuallySortedPins="true" />
               <Node Bounds="671,1497,67,19" Id="IrgzBt3WaEEPVv5Tenoku8">
-                <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Translation" />
                 </p:NodeReference>
@@ -111,7 +111,7 @@
                 <Pin Id="UEmA96bmhZ8MhsXWbppQO3" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="671,1466,46,19" Id="F0bZGc5O45ANfhjftW20rS">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -124,12 +124,12 @@
             </Patch>
           </Node>
           <Pad Id="IoAIxXXZNdHL1BWyyHdWxq" Comment="Count" Bounds="753,1375,20,15" ShowValueBox="true" isIOBox="true" Value="8">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="298,1574,76,19" Id="FyIEBQiTQJTMziJu3dzWQg">
-            <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="UniformScale" />
               <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -141,12 +141,12 @@
             <Pin Id="RUieguJYj8eMVapCMlz9M4" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="Bpf9WbTWAhqMuGPGNmQhHa" Comment="Scaling" Bounds="371,1555,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="671,1612,65,19" Id="CTLSSCQU5obOy5WsuFUXDR">
-            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="FromValue" />
               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -155,19 +155,19 @@
             <Pin Id="UMvglgwE5V1LBW9meDW2ia" Name="Result" Kind="OutputPin" />
           </Node>
           <Node Bounds="411,1688,185,19" Id="UcYNPvP2gp3NECwEzL4jMo">
-            <p:NodeReference LastCategoryFullName="Stride.Lights" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="DirectionalLight" />
             </p:NodeReference>
             <Pin Id="MB5S5tQBrIUP6V0SfTlFl9" Name="Position" Kind="InputPin" DefaultValue="0.98, 1.7, -0.64">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="ULDmES2tglZLoFJwQXCHmT" Name="Target" Kind="InputPin" />
             <Pin Id="HJvoWBNe8U7Orbs76FAz0j" Name="Color" Kind="InputPin" />
             <Pin Id="J96VNKbAozlMgI0suvVKDb" Name="Intensity" Kind="InputPin" DefaultValue="2.97">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -180,7 +180,7 @@
             <Pin Id="REGURjqM1FiOeHD0NiqmLz" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="523,1722,205,19" Id="HYDa6X0B2KxNUs23dFpDCp">
-            <p:NodeReference LastCategoryFullName="Stride.Lights" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SkyboxLight" />
             </p:NodeReference>
@@ -188,7 +188,7 @@
             <Pin Id="RqoqszxnrhoOgDp9oteH1a" Name="Cube Map" Kind="InputPin" />
             <Pin Id="QwEZnuG9agiPwLEQUZeNJr" Name="Is Specular Only" Kind="InputPin" />
             <Pin Id="HOfCavGAaotMPKAuKiK6od" Name="Intensity" Kind="InputPin" DefaultValue="0.15">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -202,7 +202,7 @@
             <Pin Id="CBXHknyx92AQFfd83bzyL3" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="398,1494,225,19" Id="SZer0JHZNxzMn24u8jCMJJ">
-            <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Materials" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="PBRMaterial (Metallic)" />
             </p:NodeReference>
@@ -221,27 +221,27 @@
             <Pin Id="KpYx7fbp3O9NaqCO8RkQKQ" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="671,1394,85,19" Id="BGGx628GHmiNz7ezOGVoZd">
-            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LinearSpread" />
             </p:NodeReference>
             <Pin Id="K12PSQ4wznJMNC40piWAcX" Name="Center" Kind="InputPin" DefaultValue="2" />
             <Pin Id="LFYEjbFg8fjQcdsC3N6JPR" Name="Width" Kind="InputPin" DefaultValue="100">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="QacMm6yr4qyO5QYRJb5Het" Name="Alignment" Kind="InputPin" />
             <Pin Id="AgjIK4rfrN6PW3U5lYNYii" Name="Phase" Kind="InputPin" />
             <Pin Id="ITZ455qMTXQNl9tYnDkBop" Name="Count" Kind="InputPin" DefaultValue="7">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="QeHsozLrKM9NbGkNd7rnDz" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="671,1570,147,19" Id="NTNdMRnPH00NrOlSZOCyaD">
-            <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="InstancingSpreadComponent" />
             </p:NodeReference>
@@ -252,14 +252,14 @@
             <Pin Id="KzIWfOxMC8JLesLWOWh4n1" Name="Component" Kind="OutputPin" />
           </Node>
           <Node Bounds="388,18,87,19" Id="GJhV14MaQqoPzhRyDNVlTq">
-            <p:NodeReference LastCategoryFullName="System.Application" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="System.Application" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ApplicationPath" />
             </p:NodeReference>
             <Pin Id="EnKNcb2wa1LL6rcVcsJyVi" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="388,91,95,19" Id="LuMIcRdPHH8PCAr9yzLdWt">
-            <p:NodeReference LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="MakePath" />
             </p:NodeReference>
@@ -268,12 +268,12 @@
             <Pin Id="C3mIZrXgCUTNnPLevKgQJh" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="B3f7nZ6RfnlMGYRRqZqhxJ" Comment="" Bounds="480,59,119,15" ShowValueBox="true" isIOBox="true" Value="..\resources\textures">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="388,185,85,19" Id="IXi3mDo3XvjMkOBYXYz4eN">
-            <p:NodeReference LastCategoryFullName="IO.Path" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Dir" />
             </p:NodeReference>
@@ -285,7 +285,7 @@
             <Pin Id="EflrQlM96n9M33lNeGMFQV" Name="Files" Kind="OutputPin" />
           </Node>
           <Node Bounds="468,119,57,19" Id="EpWK7SuCgjBMD4sUatGwwI">
-            <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Changed" />
             </p:NodeReference>
@@ -294,7 +294,7 @@
             <Pin Id="AxOn6Ug0wjyNFolAYX2wI5" Name="Unchanged" Kind="OutputPin" />
           </Node>
           <Node Bounds="468,148,71,19" Id="VZeNKRP5KdQOZtTB0ptOH1">
-            <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="OR" />
             </p:NodeReference>
@@ -303,7 +303,7 @@
             <Pin Id="Vq9ZJCvW6K2O9HSXW90bpl" Name="Output" Kind="StateOutputPin" />
           </Node>
           <Pad Id="Lw3Oj6qN5K7N54qLO6GtXv" Comment="" Bounds="536,122,35,26" ShowValueBox="true" isIOBox="true" Value="False">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <CategoryReference Kind="Category" Name="Primitive" />
             </p:TypeAnnotation>
@@ -312,7 +312,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Node Bounds="398,1379,49,19" Id="PKuYn4nvrYULVo1CczUJJS">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Sample (Vector4)" />
             </p:NodeReference>
@@ -320,7 +320,7 @@
             <Pin Id="EEo1YX3D1nJNOHbDWleoW4" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="333,294,60,19" Id="Ux5KaHsgZOcQB4arsPjmYf">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="FromFiles" />
             </p:NodeReference>
@@ -330,17 +330,17 @@
             <Pin Id="JQ1thDAzrsmPoZ2k3cmg72" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="T73SNbUq2nyN1RE2bmS2Lv" Comment="Roughness" Bounds="440,1457,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="JEw2kuCxPJEL5iYwZgRkQe" Comment="Metalness" Bounds="420,1433,35,15" ShowValueBox="true" isIOBox="true" Value="0.5">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="298,1640,205,19" Id="LCgSg78BOXkP5wY55MsTz2">
-            <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Plane" />
             </p:NodeReference>
@@ -357,18 +357,18 @@
             <Pin Id="KZERhU4XSUjPGux1o9Msfs" Name="Enabled" Kind="InputPin" />
             <Pin Id="NqKgUcPsYL0OTSKy9taEmo" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Node Bounds="333,349,52,19" Id="BJO8cbjoqIlLMVZPPTUZxM">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+          <Node Bounds="333,349,65,19" Id="BJO8cbjoqIlLMVZPPTUZxM">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="GetSlice" />
               <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
+              <Choice Kind="ProcessAppFlag" Name="GetItem" />
             </p:NodeReference>
             <Pin Id="G0KugeALLNTQKAZqeKnQaO" Name="Input" Kind="InputPin" />
             <Pin Id="KEwCyNFOh99LcYv5Lqs4pE" Name="Index" Kind="InputPin" DefaultValue="-7" />
             <Pin Id="QLaVJPG9NPeNrcIcFXp8tK" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="627,277,45,19" Id="GntcQAVIhXoQb9YaYHaFyr">
-            <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl">
+            <p:NodeReference LastCategoryFullName="Animation" LastDependency="CoreLibBasics.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LFO" />
             </p:NodeReference>
@@ -380,7 +380,7 @@
             <Pin Id="VRJg3p0DPZvOsjgBoeG1om" Name="Cycles" Kind="OutputPin" />
           </Node>
           <Node Bounds="396,864,78,19" Id="AVL251lUGUELM21uYIlEyu">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="New2DArray" />
             </p:NodeReference>
@@ -392,32 +392,33 @@
             <Pin Id="UHIeavPWMd2PhUdar2KwZI" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="DZNDJQOfEneMGu6Ks7Z4Cp" Comment="SIze" Bounds="398,812,35,28" ShowValueBox="true" isIOBox="true" Value="512, 512">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Int2" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="Rot9BN4BOOTQbFqPRYJfNq" Comment="Array Size" Bounds="471,834,40,16" ShowValueBox="true" isIOBox="true" Value="8">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="396,1009,51,19" Id="TzTJr789yPtPX0ik4Ci21A">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+          <Node Bounds="396,1009,222,19" Id="TzTJr789yPtPX0ik4Ci21A">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="SetSlice" />
               <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetItem" />
             </p:NodeReference>
             <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
             <Pin Id="Pm3mfxrO5a6O9O4cvSf1xq" Name="Input" Kind="InputPin" />
             <Pin Id="ViiwvsfvQWANN2f8Q9ektC" Name="Value" Kind="InputPin" />
             <Pin Id="Grhhb3jm5IMNBIYH6eekk5" Name="Index" Kind="InputPin" DefaultValue="0" />
+            <Pin Id="JO7i0XELzOJOnxzLYzt7K3" Name="Apply" Kind="InputPin" />
             <Pin Id="EoeQfaR4T2ZLFbylp1dEO8" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="613,1091,52,19" Id="BfEWtcLC4c5NxQGIfcc5f8">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="GetSlice" />
               <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
+              <Choice Kind="ProcessAppFlag" Name="GetItem" />
             </p:NodeReference>
             <Pin Id="Ei6rOBsiF4SLJH3NLIW6v4" Name="Input" Kind="InputPin" />
             <Pin Id="CJziQANYZDUOBt6Tds4qKo" Name="Index" Kind="InputPin" DefaultValue="-9" />
@@ -425,7 +426,7 @@
           </Node>
           <Pad Id="Ca85xgzvFj9MfwoKvaExWS" Comment="" Bounds="615,1133,110,170" ShowValueBox="true" isIOBox="true" />
           <Node Bounds="333,578,68,26" Id="SNnKgjDHrYxMbfgs7siwrl">
-            <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
+            <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="Description" />
               <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
@@ -439,7 +440,7 @@
             <Pin Id="GfSruEimBPyQcv0IEQqyB4" Name="Description" Kind="OutputPin" />
           </Node>
           <Node Bounds="396,762,176,19" Id="L7OLNJeoMHlP6ZMfvrcIIW">
-            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="VL.Addons.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="TextureDescription" />
               <Choice Kind="OperationCallFlag" Name="Split" />
@@ -456,8 +457,8 @@
             <Pin Id="QHHsaE0cMHNL1zCO9qjngZ" Name="Usage" Kind="OutputPin" />
           </Node>
           <Pad Id="SRN9KYqnELsQGxl6LsCqsE" Comment="" Bounds="335,383,110,178" ShowValueBox="true" isIOBox="true" />
-          <Node Bounds="648,885,147,108" Id="IlgX3Mf2NMmL2r1fjZckGA">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+          <Node Bounds="648,870,147,109" Id="IlgX3Mf2NMmL2r1fjZckGA">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="ProcessStatefulRegion" Name="Cache" />
               <FullNameCategoryReference ID="Primitive" />
             </p:NodeReference>
@@ -467,8 +468,8 @@
             <Patch Id="JVdB2j1jeQdLHRnx1Q2UMz" ManuallySortedPins="true">
               <Patch Id="VbVUqyZBzsHNCHHSq0fPDM" Name="Create" ManuallySortedPins="true" />
               <Patch Id="Q9DYuRlwkGZQA8PSSGHdG4" Name="Then" ManuallySortedPins="true" />
-              <Node Bounds="660,953,54,19" Id="U3mZ7fLfaXwOHD9kFETgXK">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+              <Node Bounds="660,938,54,19" Id="U3mZ7fLfaXwOHD9kFETgXK">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Random" />
                 </p:NodeReference>
@@ -476,8 +477,8 @@
                 <Pin Id="Od7RnygjK2iOQ41jlFVY6x" Name="To" Kind="InputPin" />
                 <Pin Id="HYiXM0Za0oBMNa3YWkZCc7" Name="Output" Kind="OutputPin" />
               </Node>
-              <Node Bounds="709,926,25,19" Id="NlwpvxrIkl0P5LQnNcMWlt">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+              <Node Bounds="709,911,25,19" Id="NlwpvxrIkl0P5LQnNcMWlt">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="-" />
                 </p:NodeReference>
@@ -485,17 +486,17 @@
                 <Pin Id="GhWM6QDUnXGPyIn1yjIrj3" Name="Input 2" Kind="InputPin" DefaultValue="-1" />
                 <Pin Id="IKh1j9empy9OY9FiJGwukG" Name="Output" Kind="OutputPin" />
               </Node>
-              <Pad Id="KwGB1utAXVALQhCs43WB4B" Comment="" Bounds="729,913,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <Pad Id="KwGB1utAXVALQhCs43WB4B" Comment="" Bounds="729,898,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
             </Patch>
-            <ControlPoint Id="B1cY4ID6cakLncyIe2H0MD" Bounds="662,988" Alignment="Bottom" />
+            <ControlPoint Id="B1cY4ID6cakLncyIe2H0MD" Bounds="662,973" Alignment="Bottom" />
           </Node>
           <ControlPoint Id="VO7qYH8vPTILQPJZ9ryuHo" Bounds="334,980" />
-          <Pad Id="KzaEoAGMyjGOex4jrOeeV7" Bounds="203,1020,178,62" ShowValueBox="true" isIOBox="true" Value="Setting a slice and the result might not happen in the same frame !">
-            <p:TypeAnnotation>
+          <Pad Id="KzaEoAGMyjGOex4jrOeeV7" Bounds="203,1020,178,62" ShowValueBox="true" isIOBox="true" Value="Setting an item and the result might not happen in the same frame !">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -560,9 +561,10 @@
         <Link Id="KtR44IwRw19PuOOcVEKdoE" Ids="EoeQfaR4T2ZLFbylp1dEO8,Ppe5Jp16nSsMPNb8FoExaX" />
         <Link Id="BSL8l7yGjQQNNnNA3lm4DM" Ids="NqKgUcPsYL0OTSKy9taEmo,E29fcB8RUegMvtHIfG57Hd" />
         <Link Id="J0phXq9tP0PNEJxbnwmwog" Ids="REGURjqM1FiOeHD0NiqmLz,Bu0kGOCIOJ7NkCb2GAUNC3" />
+        <Link Id="DccQRfGYgLXNynTKC5Ozlb" Ids="PPwUxw572jDQC3pc8mazuS,JO7i0XELzOJOnxzLYzt7K3" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0485-g8f46e4a34a" />
+  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0696-g73767f5671" />
   <DocumentDependency Id="RRxCwek5VyaMuspvq1vIBA" Location="../vl/VL.Addons.Stride.vl" />
 </Document>

--- a/help/HowTo Use SetItem(TextureArray).vl
+++ b/help/HowTo Use SetItem(TextureArray).vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="Jm4K8HLevsLMUvbXpCVnn2" LanguageVersion="2022.5.0-0696-g73767f5671" Version="0.128">
-  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0696-g73767f5671" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="Jm4K8HLevsLMUvbXpCVnn2" LanguageVersion="2022.5.0-0735-ge3039d4101" Version="0.128">
+  <NugetDependency Id="Q17KbXI0mcuMV42CAG18Pr" Location="VL.CoreLib" Version="2022.5.0-0735-ge3039d4101" />
   <Patch Id="S25Gr1WMWcMQSRiHRWO4uq">
     <Canvas Id="GH8DZEWEW7hN2B8H0Xzxf8" DefaultCategory="Stride" CanvasType="FullCategory" />
     <!--
@@ -43,7 +43,7 @@
             <Pin Id="Bj1x0fD7s0CQT167itkrYA" Name="Input" Kind="InputPin" />
             <Pin Id="OrdLrvpbF6XOcoxvXdlDRD" Name="Camera" Kind="InputPin" />
             <Pin Id="UbPOJ1618wcLjfXAw7e2Cj" Name="Enable Default Camera" Kind="InputPin" />
-            <Pin Id="H05NC6jz4AWOAELriOI8n7" Name="Title" Kind="InputPin" DefaultValue="SetSlice (TextureArray)" />
+            <Pin Id="H05NC6jz4AWOAELriOI8n7" Name="Title" Kind="InputPin" DefaultValue="SetItem (TextureArray)" />
             <Pin Id="DhtYpD9PZj1LpIaEd4qCSx" Name="Clear Color" Kind="InputPin" />
             <Pin Id="TNXpkhnIxYmPACqYkKAr1s" Name="Clear" Kind="InputPin" />
             <Pin Id="GcBruHn3w0eOiZDNeFqvLJ" Name="Post Effects" Kind="InputPin" />
@@ -124,7 +124,7 @@
             </Patch>
           </Node>
           <Pad Id="IoAIxXXZNdHL1BWyyHdWxq" Comment="Count" Bounds="753,1375,20,15" ShowValueBox="true" isIOBox="true" Value="8">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
@@ -141,7 +141,7 @@
             <Pin Id="RUieguJYj8eMVapCMlz9M4" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="Bpf9WbTWAhqMuGPGNmQhHa" Comment="Scaling" Bounds="371,1555,35,15" ShowValueBox="true" isIOBox="true" Value="0.099999994">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
@@ -368,7 +368,7 @@
             <Pin Id="QLaVJPG9NPeNrcIcFXp8tK" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="627,277,45,19" Id="GntcQAVIhXoQb9YaYHaFyr">
-            <p:NodeReference LastCategoryFullName="Animation" LastDependency="CoreLibBasics.vl">
+            <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LFO" />
             </p:NodeReference>
@@ -392,16 +392,16 @@
             <Pin Id="UHIeavPWMd2PhUdar2KwZI" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="DZNDJQOfEneMGu6Ks7Z4Cp" Comment="SIze" Bounds="398,812,35,28" ShowValueBox="true" isIOBox="true" Value="512, 512">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Int2" />
             </p:TypeAnnotation>
           </Pad>
           <Pad Id="Rot9BN4BOOTQbFqPRYJfNq" Comment="Array Size" Bounds="471,834,40,16" ShowValueBox="true" isIOBox="true" Value="8">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="396,1009,222,19" Id="TzTJr789yPtPX0ik4Ci21A">
+          <Node Bounds="396,1033,222,19" Id="TzTJr789yPtPX0ik4Ci21A">
             <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
@@ -409,8 +409,8 @@
             </p:NodeReference>
             <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
             <Pin Id="Pm3mfxrO5a6O9O4cvSf1xq" Name="Input" Kind="InputPin" />
-            <Pin Id="ViiwvsfvQWANN2f8Q9ektC" Name="Value" Kind="InputPin" />
             <Pin Id="Grhhb3jm5IMNBIYH6eekk5" Name="Index" Kind="InputPin" DefaultValue="0" />
+            <Pin Id="ViiwvsfvQWANN2f8Q9ektC" Name="Value" Kind="InputPin" />
             <Pin Id="JO7i0XELzOJOnxzLYzt7K3" Name="Apply" Kind="InputPin" />
             <Pin Id="EoeQfaR4T2ZLFbylp1dEO8" Name="Output" Kind="OutputPin" />
           </Node>
@@ -426,7 +426,7 @@
           </Node>
           <Pad Id="Ca85xgzvFj9MfwoKvaExWS" Comment="" Bounds="615,1133,110,170" ShowValueBox="true" isIOBox="true" />
           <Node Bounds="333,578,68,26" Id="SNnKgjDHrYxMbfgs7siwrl">
-            <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+            <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="Description" />
               <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
@@ -457,7 +457,7 @@
             <Pin Id="QHHsaE0cMHNL1zCO9qjngZ" Name="Usage" Kind="OutputPin" />
           </Node>
           <Pad Id="SRN9KYqnELsQGxl6LsCqsE" Comment="" Bounds="335,383,110,178" ShowValueBox="true" isIOBox="true" />
-          <Node Bounds="648,870,147,109" Id="IlgX3Mf2NMmL2r1fjZckGA">
+          <Node Bounds="648,870,147,113" Id="IlgX3Mf2NMmL2r1fjZckGA">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="ProcessStatefulRegion" Name="Cache" />
               <FullNameCategoryReference ID="Primitive" />
@@ -465,11 +465,12 @@
             <Pin Id="CcSfrEX7AUfN2g2i0f1nnD" Name="Force" Kind="InputPin" />
             <Pin Id="RNkzEbh1WJ1QeAoAlaP6nQ" Name="Dispose Cached Outputs" Kind="InputPin" />
             <Pin Id="PPwUxw572jDQC3pc8mazuS" Name="Has Changed" Kind="OutputPin" />
+            <ControlPoint Id="B1cY4ID6cakLncyIe2H0MD" Bounds="662,977" Alignment="Bottom" />
             <Patch Id="JVdB2j1jeQdLHRnx1Q2UMz" ManuallySortedPins="true">
               <Patch Id="VbVUqyZBzsHNCHHSq0fPDM" Name="Create" ManuallySortedPins="true" />
               <Patch Id="Q9DYuRlwkGZQA8PSSGHdG4" Name="Then" ManuallySortedPins="true" />
               <Node Bounds="660,938,54,19" Id="U3mZ7fLfaXwOHD9kFETgXK">
-                <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Random" />
                 </p:NodeReference>
@@ -478,7 +479,7 @@
                 <Pin Id="HYiXM0Za0oBMNa3YWkZCc7" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="709,911,25,19" Id="NlwpvxrIkl0P5LQnNcMWlt">
-                <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="-" />
                 </p:NodeReference>
@@ -487,15 +488,23 @@
                 <Pin Id="IKh1j9empy9OY9FiJGwukG" Name="Output" Kind="OutputPin" />
               </Node>
               <Pad Id="KwGB1utAXVALQhCs43WB4B" Comment="" Bounds="729,898,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
             </Patch>
-            <ControlPoint Id="B1cY4ID6cakLncyIe2H0MD" Bounds="662,973" Alignment="Bottom" />
           </Node>
           <ControlPoint Id="VO7qYH8vPTILQPJZ9ryuHo" Bounds="334,980" />
           <Pad Id="KzaEoAGMyjGOex4jrOeeV7" Bounds="203,1020,178,62" ShowValueBox="true" isIOBox="true" Value="Setting an item and the result might not happen in the same frame !">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="IUsAtsU8xF0LfiWJHWU3Gw" Bounds="628,1033,171,19" ShowValueBox="true" isIOBox="true" Value="&lt;- Apply is an optional pin">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -565,6 +574,6 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0696-g73767f5671" />
+  <NugetDependency Id="JGeaopK3ASqLipgvfkzoPS" Location="VL.Stride" Version="2022.5.0-0735-ge3039d4101" />
   <DocumentDependency Id="RRxCwek5VyaMuspvq1vIBA" Location="../vl/VL.Addons.Stride.vl" />
 </Document>

--- a/vl/VL.Addons.Stride.vl
+++ b/vl/VL.Addons.Stride.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="Cp8BLHoIN3nMQUGZkhFpJw" LanguageVersion="2022.5.0-0696-g73767f5671" Version="0.128">
-  <NugetDependency Id="GFBaA1xQ5F2NjgUCO9vziQ" Location="VL.CoreLib" Version="2022.5.0-0696-g73767f5671" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="Cp8BLHoIN3nMQUGZkhFpJw" LanguageVersion="2022.5.0-0735-ge3039d4101" Version="0.128">
+  <NugetDependency Id="GFBaA1xQ5F2NjgUCO9vziQ" Location="VL.CoreLib" Version="2022.5.0-0735-ge3039d4101" />
   <Patch Id="VeJSap7sIKJNwnBokjEoI8">
     <Canvas Id="KAeiw0WXEdQNQT9FSe5ubO" DefaultCategory="Stride" CanvasType="FullCategory">
       <Canvas Id="La2rwazVWI1LNRD2Wi4LG0" Name="Graphics" Position="298,128">
@@ -201,7 +201,7 @@
                     <Pin Id="DuRHSpM3dD3OlDSOfcrVpk" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Pad Id="Mihku1irHW3PFb0pEF6G84" Comment="Load As SRGB" Bounds="209,156,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -732,7 +732,7 @@
                     </Patch>
                   </Node>
                   <Pad Id="RjKTRtOgEycNIKApmSbo8s" Comment="Dispose Cached Outputs" Bounds="200,103,35,15" ShowValueBox="true" isIOBox="true" Value="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -800,7 +800,7 @@
                     </Patch>
                   </Node>
                   <Pad Id="FsA99bl9NBKLhZZiCkEmVs" Comment="Dispose Cached Outputs" Bounds="172,83,35,24" ShowValueBox="true" isIOBox="true" Value="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -1151,7 +1151,7 @@
                         <Pin Id="F5tXy1PanI6PkLg2fTP4D2" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="BrWYP7jBdiVP4VLIdGAHsl" Comment="" Bounds="504,293,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Integer32" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -1275,7 +1275,7 @@
                                 </Patch>
                               </Node>
                               <Pad Id="VzXYJAIu3IlMOMz1WPbMwV" Comment="" Bounds="217,851,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="Boolean" />
                                 </p:TypeAnnotation>
                               </Pad>
@@ -1541,7 +1541,7 @@
                         <Pin Id="Lh17VM87AuDLHMrsqxekie" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="EkFH07zqFqNPX0U6XkjwSS" Comment="" Bounds="511,261,20,15" ShowValueBox="true" isIOBox="true" Value="1">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Integer32" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -1919,7 +1919,7 @@
                         <Pin Id="H3LdLHsgF6OQL0NZgD4d5m" Name="Composition" Kind="InputPin" />
                       </Node>
                       <Pad Id="PAnc1g3kaZ9L2QbI7RxCqb" Comment="" Bounds="112,166,148,15" ShowValueBox="true" isIOBox="true" Value="SampleTextureArrayVector4">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -1937,7 +1937,7 @@
                     <Pin Id="NDPu3WaG9gcQF4FUW1M4dR" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="DJP1o3LOXc9NedHOTKY6YV" Comment="" Bounds="303,211,91,18" ShowValueBox="true" isIOBox="true" Value="ArrayTextureSize">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -1951,7 +1951,7 @@
                     <Pin Id="JcFoFPEZGaLMyZtwDcM8hR" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="RKLOkfvRhuaNsYIAM7Fxjr" Comment="" Bounds="519,226,74,15" ShowValueBox="true" isIOBox="true" Value="ArrayTexture">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2045,7 +2045,7 @@
               <Patch Id="KsztQwaa0EtLZLfMSuX6sI">
                 <Canvas Id="SMXx88tA1XKNxwPSyAysJ1" CanvasType="Group">
                   <Node Bounds="102,367,305,19" Id="LlpKgw4B0EJQB6EICoKo0K">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\dev\vvvv\vl-libs_22-5\VL.Addons\vl)">
                       <Choice Kind="ProcessNode" Name="ArrayTextureInstancedShader" />
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     </p:NodeReference>
@@ -2169,7 +2169,7 @@
                     <Pin Id="HMGBsaujHyHMso2mLcbrXr" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Pad Id="MhdgIIUiDdNNlEa7wTVK3X" Comment="Scaling" Bounds="415,302,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2284,7 +2284,7 @@
                     <Pin Id="FCaArb1v3uRNiVccZzATAu" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Pad Id="UzKS6NFrkLzQCb8ZazQPbs" Comment="" Bounds="827,364,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2292,7 +2292,7 @@
                   <ControlPoint Id="UeJ3BcHapwlNhl9SAPEzQt" Bounds="885,454" />
                   <ControlPoint Id="UI6tstHgQoJQaVQyqVRYgn" Bounds="807,278" />
                   <Pad Id="GCdX94eFNjhLhdKUX02eUh" Comment="Scaling" Bounds="619,562,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2381,7 +2381,7 @@
               </p:NodeReference>
               <Patch Id="PCY7JrOAt3AOXamFva7bRg">
                 <Canvas Id="Fz0NFBa0MWcLXa68ISzLKK" CanvasType="Group">
-                  <Node Bounds="147,345,205,112" Id="NTFIvXezQsyQRcfD0vbgEg">
+                  <Node Bounds="147,345,240,113" Id="NTFIvXezQsyQRcfD0vbgEg">
                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -2406,8 +2406,8 @@
                         <Pin Id="NLVnXfDJseNQbvP0achX3h" Name="Compute Node" Kind="OutputPin" />
                         <Pin Id="FIiQN1t3QWDOmGOYQOKCjg" Name="Composition" Kind="InputPin" />
                       </Node>
-                      <Pad Id="Cd5hBIT91acNHdncgCQqDz" Comment="" Bounds="163,373,193,14" ShowValueBox="true" isIOBox="true" Value="SampleTextureArrayVector4WithIndex">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                      <Pad Id="Cd5hBIT91acNHdncgCQqDz" Comment="" Bounds="163,373,193,15" ShowValueBox="true" isIOBox="true" Value="SampleTextureArrayVector4WithIndex">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -2425,7 +2425,7 @@
                     <Pin Id="JjTVpmoTBuzPbAZGZWhjvZ" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="BjCnd8sIT2tLIC0cpPiT2K" Comment="" Bounds="401,303,91,18" ShowValueBox="true" isIOBox="true" Value="ArrayTextureSize">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2439,7 +2439,7 @@
                     <Pin Id="LCY7rPQ4Y60Pq40MMOg1m8" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="MEPnK7pDg4nLy0wLTAYlzf" Comment="" Bounds="701,405,74,15" ShowValueBox="true" isIOBox="true" Value="ArrayTexture">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2492,7 +2492,7 @@
                     <Pin Id="Vg3zB8mcDaqL2FF3KrfYiY" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="E78hFfD4GP5Nmu6Kh3l3RX" Comment="" Bounds="851,405,74,15" ShowValueBox="true" isIOBox="true" Value="Indices">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2506,7 +2506,7 @@
                     <Pin Id="R0Y7JGnSuPKPdacaEEPaH1" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="C6F011lkchRP3ZXO2AorYo" Comment="" Bounds="551,405,91,18" ShowValueBox="true" isIOBox="true" Value="IndicesSize">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2865,7 +2865,7 @@
                                 <ControlPoint Id="UZaVchImG76NRxg81mRoz7" Bounds="599,1053" Name="targetTex" Alignment="Bottom" />
                               </Node>
                               <Pad Id="RnKk02EkQGwOsJASH8sQUt" Comment="" Bounds="356,932,35,28" ShowValueBox="true" isIOBox="true" Value="True">
-                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="Boolean" />
                                 </p:TypeAnnotation>
                               </Pad>
@@ -3353,7 +3353,7 @@
               </p:NodeReference>
               <Patch Id="FHZfvXzBUB3LLbLa9NqYCT">
                 <Canvas Id="TzsGaZQfF0zOzGVCSkeTGY" CanvasType="Group">
-                  <ControlPoint Id="HIp7VuQz2xxNdqvsb0tJ2w" Bounds="210,48" />
+                  <ControlPoint Id="HIp7VuQz2xxNdqvsb0tJ2w" Bounds="292,48" />
                   <Node Bounds="77,724,92,19" Id="K6YFmVeGv3sO1wJXQtO3m6">
                     <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -3375,14 +3375,14 @@
                     <Pin Id="Vnjfs55ohZBLaE7l1zD3dc" Name="Command List" Kind="OutputPin" />
                   </Node>
                   <ControlPoint Id="SWkG6WEMgZdO6cmslVMQ23" Bounds="602,48" />
-                  <ControlPoint Id="VD0P42nfdKxLoS5tWM7WOB" Bounds="546,48" />
+                  <ControlPoint Id="VD0P42nfdKxLoS5tWM7WOB" Bounds="212,48" />
                   <Node Bounds="210,286,688,734" Id="H56kwVfuRt9Owv85mtl3V1">
                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <FullNameCategoryReference ID="Primitive" />
                     </p:NodeReference>
                     <Pin Id="Jut8Tv3rnPMMH9xo9UGPaJ" Name="Condition" Kind="InputPin" DefaultValue="True" />
-                    <ControlPoint Id="LRT3iEw0sG9NicmC55Nx5r" Bounds="546,292" Name="texArray" Alignment="Top" />
+                    <ControlPoint Id="LRT3iEw0sG9NicmC55Nx5r" Bounds="545,292" Name="texArray" Alignment="Top" />
                     <ControlPoint Id="DK2W2Ad0QJvNgqRu7ONgkZ" Bounds="547,1014" Name="texArray" Alignment="Bottom" />
                     <Patch Id="KjV3qh8REltPsQmGVBnw9b" ManuallySortedPins="true">
                       <Patch Id="ILRYuR9FkLAPIkBGx88QKE" Name="Create" ManuallySortedPins="true" />
@@ -3443,7 +3443,7 @@
                         <Pin Id="Pw1COadH9fAM8oWXvWgW16" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="QyV087b5PSnODHBzvteJjw" Comment="" Bounds="329,486,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Integer32" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -3464,6 +3464,10 @@
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:NodeReference>
                         <Pin Id="FDm7SiLstazMoV0UV5T2QH" Name="Condition" Kind="InputPin" />
+                        <ControlPoint Id="TR5M6SlBzD0M2kqS5evDGr" Bounds="545,592" Name="texArray" Alignment="Top" />
+                        <ControlPoint Id="Fyhx3cDXTPfOOHutv4ys7d" Bounds="547,994" Name="texArray" Alignment="Bottom" />
+                        <ControlPoint Id="BQVyq1Tgif1QdDaXCHN3gC" Bounds="317,592" Name="InputTexture" Alignment="Top" />
+                        <ControlPoint Id="SGGifcgnNQpL1as1MapbgQ" Bounds="317,994" Name="InputTexture" Alignment="Bottom" />
                         <Patch Id="I99O69ZlqmjPMYXOXp9QmV" ManuallySortedPins="true">
                           <Patch Id="P3Gewnt6rWiOfUiFRiRJW0" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="VdT60bvZitKNRev92otmzU" Name="Then" ManuallySortedPins="true" />
@@ -3475,6 +3479,10 @@
                             </p:NodeReference>
                             <Pin Id="OjgvyfovMlBM9lyCmEVRD3" Name="Iteration Count" Kind="InputPin" />
                             <Pin Id="QIGwD6wDaWhOqh64XYDc5x" Name="Break" Kind="OutputPin" />
+                            <ControlPoint Id="DCnbJ8mX9akPLBxS9a3B6S" Bounds="546,686" Name="texArray" Alignment="Top" />
+                            <ControlPoint Id="H2ry8qmaHHsMPHFF8VWB6d" Bounds="547,972" Name="texArray" Alignment="Bottom" />
+                            <ControlPoint Id="F31e4c03joJPu0hkIX6zBq" Bounds="317,686" Name="InputTexture" Alignment="Top" />
+                            <ControlPoint Id="HTL7pl9zVbNOPWoGjkSVyy" Bounds="317,972" Name="InputTexture" Alignment="Bottom" />
                             <Patch Id="ExvRe5cbktNMc94GyHzErZ" ManuallySortedPins="true">
                               <Patch Id="FPubDOaor0fOGRUK614dGJ" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="HepvLAvEJx7N9YFxM38YUM" Name="Update" ManuallySortedPins="true">
@@ -3515,7 +3523,7 @@
                                 <ControlPoint Id="VMXavRrOZxfNwRV7gVg4bN" Bounds="547,942" Name="texArray" Alignment="Bottom" />
                               </Node>
                               <Pad Id="FInZbU1HBrCOqHHRkXpY33" Comment="" Bounds="305,816,35,15" ShowValueBox="true" isIOBox="true" Value="True">
-                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="Boolean" />
                                 </p:TypeAnnotation>
                               </Pad>
@@ -3544,10 +3552,6 @@
                                 <Pin Id="EvC61M3MQVhN061vDKTLBn" Name="Result" Kind="OutputPin" />
                               </Node>
                             </Patch>
-                            <ControlPoint Id="DCnbJ8mX9akPLBxS9a3B6S" Bounds="546,686" Name="texArray" Alignment="Top" />
-                            <ControlPoint Id="H2ry8qmaHHsMPHFF8VWB6d" Bounds="547,972" Name="texArray" Alignment="Bottom" />
-                            <ControlPoint Id="F31e4c03joJPu0hkIX6zBq" Bounds="317,686" Name="InputTexture" Alignment="Top" />
-                            <ControlPoint Id="HTL7pl9zVbNOPWoGjkSVyy" Bounds="317,972" Name="InputTexture" Alignment="Bottom" />
                           </Node>
                           <Node Bounds="423,609,85,26" Id="CGFjd27ZThRLcnjI9AdWo2">
                             <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
@@ -3559,12 +3563,8 @@
                             <Pin Id="TKlxP4vMWEvOcKYBxleNDq" Name="Mip Levels" Kind="OutputPin" />
                           </Node>
                         </Patch>
-                        <ControlPoint Id="TR5M6SlBzD0M2kqS5evDGr" Bounds="545,592" Name="texArray" Alignment="Top" />
-                        <ControlPoint Id="Fyhx3cDXTPfOOHutv4ys7d" Bounds="547,994" Name="texArray" Alignment="Bottom" />
-                        <ControlPoint Id="BQVyq1Tgif1QdDaXCHN3gC" Bounds="317,592" Name="InputTexture" Alignment="Top" />
-                        <ControlPoint Id="SGGifcgnNQpL1as1MapbgQ" Bounds="317,994" Name="InputTexture" Alignment="Bottom" />
                       </Node>
-                      <Node Bounds="544,387,112,26" Id="U4iws7SnW7bMtLBrDGiPTe">
+                      <Node Bounds="543,387,113,26" Id="U4iws7SnW7bMtLBrDGiPTe">
                         <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Description" />
@@ -3603,15 +3603,6 @@
                     <Pin Id="G2e1mmNDuTBMyJjuVWc8R4" Name="Result" Kind="OutputPin" />
                     <Pin Id="UxHLPniejRINUGJunf6sGG" Name="Not Assigned" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="289,106,57,19" Id="AtY0dXrQ1s1Lqte9tiTCFG">
-                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="Changed" />
-                    </p:NodeReference>
-                    <Pin Id="RYc2GeVOUusMNlYgkWhE2e" Name="Value" Kind="InputPin" />
-                    <Pin Id="Aq747zgq8yrPp7oj4Z9I0w" Name="Result" Kind="OutputPin" />
-                    <Pin Id="IgGlNiUU9mBLEmANfW6AVV" Name="Unchanged" Kind="OutputPin" />
-                  </Node>
                   <Node Bounds="210,245,165,19" Id="CxtnJ0dgGQ8Pt174cTQNyv">
                     <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -3624,17 +3615,7 @@
                     <Pin Id="O3bd7moqK7hO0DaOH36pEg" Name="Input 3" Kind="InputPin" />
                   </Node>
                   <ControlPoint Id="QWjoU3fmp0zMXYax1FgPgU" Bounds="547,1072" />
-                  <Node Bounds="289,203,65,19" Id="JZl6vSfc3DkNYz3cpeXA6O">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="OperationCallFlag" Name="OR" />
-                      <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
-                    </p:NodeReference>
-                    <Pin Id="S3a1ZozqISxNtFUuxkBFg1" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="FbHWbFfYD1ZOEsDPzaMYIZ" Name="Input 2" Kind="InputPin" />
-                    <Pin Id="VwdQDSNnMUuP7exINT6Xhy" Name="Output" Kind="StateOutputPin" />
-                  </Node>
-                  <Node Bounds="370,208,65,19" Id="BzG2jw0QYF0M1YVRMSKUlC">
+                  <Node Bounds="290,202,65,19" Id="BzG2jw0QYF0M1YVRMSKUlC">
                     <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="IsAssigned" />
@@ -3643,7 +3624,7 @@
                     <Pin Id="KWKhEdVIgHjOgVa6wV1D0X" Name="Result" Kind="OutputPin" />
                     <Pin Id="IIIULPqnbGiP4CBbkKnvrA" Name="Not Assigned" Kind="OutputPin" />
                   </Node>
-                  <ControlPoint Id="V3Ma7DVZkYCOP4FPoMVydT" Bounds="678,48" />
+                  <ControlPoint Id="V3Ma7DVZkYCOP4FPoMVydT" Bounds="738,48" />
                 </Canvas>
                 <ProcessDefinition Id="PB2qfHqLVDMLqsw78h6Ayk">
                   <Fragment Id="RCxLHPiVPFBNeBlAuOu4xH" Patch="K2xV1EiYGz5MstbTfHA1I3" Enabled="true" />
@@ -3657,10 +3638,10 @@
                 <Patch Id="K2xV1EiYGz5MstbTfHA1I3" Name="Create" />
                 <Patch Id="UCaSNfJDCBoPo1kaxvq8H7" Name="Update" ManuallySortedPins="true">
                   <Pin Id="CLdsjFTuWtrQA0SjtKKhwH" Name="Input" Kind="InputPin" Bounds="511,246" />
-                  <Pin Id="OPSQzc3TFM3NZ2tVrgJKwb" Name="Value" Kind="InputPin" />
                   <Pin Id="E8b3fcbr6Z2MR8z6cQ0a6v" Name="Index" Kind="InputPin" />
+                  <Pin Id="OPSQzc3TFM3NZ2tVrgJKwb" Name="Value" Kind="InputPin" />
+                  <Pin Id="TsUuDiFVri3PwHlNFSqKFj" Name="Apply" Kind="InputPin" Bounds="678,47" Visibility="Optional" />
                   <Pin Id="UoqpiZQHzHbOMyr0saaq8u" Name="Output" Kind="OutputPin" Bounds="575,973" />
-                  <Pin Id="TsUuDiFVri3PwHlNFSqKFj" Name="Apply" Kind="InputPin" Bounds="678,47" />
                 </Patch>
                 <Link Id="AQaAYIBWOPPQNwW4gG4wYk" Ids="MWXFqfYfnc4QOWXutcP6vP,E87nldJP8p0PQUZgIzSQk1" />
                 <Link Id="VV8cN6oG0p2O2omtj7UFSv" Ids="M4ht6n7s8o2P50NTEUpSgC,DyleAcAajxuPzRYeOpoz8k" />
@@ -3682,10 +3663,7 @@
                 <Link Id="LQEJjhXAy5gOjy5ejhVvvA" Ids="EvC61M3MQVhN061vDKTLBn,TTrVOKXUDLDLeZSd19Cu7S" />
                 <Link Id="AIVulFwwGppMSOsdR1pKZq" Ids="T5bw1KA6Yf1OGHhFjoqxuf,U2VYqWZm56wMW18B2jBKTq" />
                 <Link Id="ItVMpSXgHsRPftZADaFSb7" Ids="MWXFqfYfnc4QOWXutcP6vP,AzjarFPwxDyMQsMhzxCqVD" />
-                <Link Id="H3ZntQmiKQrPL28vB2vuQB" Ids="HIp7VuQz2xxNdqvsb0tJ2w,Nw6UXjjjYSVMGrlT4dBaWD" />
-                <Link Id="TuLY59hm8w1M7HGgFLLiCE" Ids="HIp7VuQz2xxNdqvsb0tJ2w,Cfri0izmESUPQUKwxWiPYX" />
                 <Link Id="NpeTQnQKqNxMQzfj3nqhJ0" Ids="MWXFqfYfnc4QOWXutcP6vP,FCRvWUFN9ktK9dV5Z3vgEn" />
-                <Link Id="QDs9WJ9KPjzPHdBhmDScxv" Ids="HIp7VuQz2xxNdqvsb0tJ2w,RYc2GeVOUusMNlYgkWhE2e" />
                 <Link Id="LhtBzU0TrNPNtm4CoQ2Ufc" Ids="G2e1mmNDuTBMyJjuVWc8R4,JwQxDLrLFtcPh4Ennwjyyr" />
                 <Link Id="Jiqjvtk84zMMXtuN4M8YEz" Ids="LRT3iEw0sG9NicmC55Nx5r,DK2W2Ad0QJvNgqRu7ONgkZ" IsFeedback="true" />
                 <Link Id="HKkNipPk6LFOx45GHkuRlX" Ids="VD0P42nfdKxLoS5tWM7WOB,LRT3iEw0sG9NicmC55Nx5r" />
@@ -3701,10 +3679,6 @@
                 <Link Id="CFN7lQ67w1kLItnoMNjOv6" Ids="Fyhx3cDXTPfOOHutv4ys7d,DK2W2Ad0QJvNgqRu7ONgkZ" />
                 <Link Id="AJYkT9OKHWnLhytfNWaS8v" Ids="DK2W2Ad0QJvNgqRu7ONgkZ,QWjoU3fmp0zMXYax1FgPgU" />
                 <Link Id="BSvFhyfAILGMOshHvUnFtd" Ids="QWjoU3fmp0zMXYax1FgPgU,UoqpiZQHzHbOMyr0saaq8u" IsHidden="true" />
-                <Link Id="LRza0DINrouMdC7xgsLFv8" Ids="Aq747zgq8yrPp7oj4Z9I0w,S3a1ZozqISxNtFUuxkBFg1" />
-                <Link Id="PTEFuMFXSxNMz4237VwVdn" Ids="VwdQDSNnMUuP7exINT6Xhy,RqhWJfbDD65OOp9g857E9i" />
-                <Link Id="HDGVag4ZEe3PTiM94FKflT" Ids="VD0P42nfdKxLoS5tWM7WOB,DYvn0ZIbBmGO7M721n9DqD" />
-                <Link Id="An0hNLCJVXiLueZ6vMWcbC" Ids="KWKhEdVIgHjOgVa6wV1D0X,O3bd7moqK7hO0DaOH36pEg" />
                 <Link Id="AmnFWTeCG8yLMXMLACMsGT" Ids="LRT3iEw0sG9NicmC55Nx5r,QFgAdeYIfY6QI6McU80QiE" />
                 <Link Id="SrhbM18YLZvNc3wTqV5BEh" Ids="Ms4AXbxUTZlLd2FR1TdWQb,QgB39JrpBJVLRpyG8vhXZQ" />
                 <Link Id="Rhv7HSTNO68M6GvTZnEKow" Ids="OJX9lk8GXMwMwAL1myeOK1,KG618mxSApePE5kIyBiWWH" />
@@ -3720,8 +3694,12 @@
                 <Link Id="Bpnntx8dNXRMm0jSSJW3mK" Ids="HTL7pl9zVbNOPWoGjkSVyy,SGGifcgnNQpL1as1MapbgQ" />
                 <Link Id="IqsEIOyjoBlQYI1w37LDu1" Ids="RZncJgYTaPbMCnwS6NBAHc,Jut8Tv3rnPMMH9xo9UGPaJ" />
                 <Link Id="URwyFs5zQZ6MTKIHTmOIln" Ids="QpVsgVegzVnLuxwgEsumHE,Gaxmcw6Bkt9M1dqvp0IdFD" />
-                <Link Id="FIhJr1FapnSNPZC5j7zgeK" Ids="V3Ma7DVZkYCOP4FPoMVydT,FbHWbFfYD1ZOEsDPzaMYIZ" />
                 <Link Id="A5gBTfS9z5QOI4fF96JzZ3" Ids="TsUuDiFVri3PwHlNFSqKFj,V3Ma7DVZkYCOP4FPoMVydT" IsHidden="true" />
+                <Link Id="BN7XAz4usehLU4DDRXCNsX" Ids="VD0P42nfdKxLoS5tWM7WOB,Nw6UXjjjYSVMGrlT4dBaWD" />
+                <Link Id="SiODR2xa66OM1cfQOIgebh" Ids="HIp7VuQz2xxNdqvsb0tJ2w,DYvn0ZIbBmGO7M721n9DqD" />
+                <Link Id="DPB3eFsKGaQPC9jgaId97I" Ids="KWKhEdVIgHjOgVa6wV1D0X,RqhWJfbDD65OOp9g857E9i" />
+                <Link Id="C5mynGxBYUCNrTb7d2FMx3" Ids="V3Ma7DVZkYCOP4FPoMVydT,O3bd7moqK7hO0DaOH36pEg" />
+                <Link Id="JQgsbemLBd1M1kQHjRk5dT" Ids="HIp7VuQz2xxNdqvsb0tJ2w,Cfri0izmESUPQUKwxWiPYX" />
               </Patch>
             </Node>
           </Canvas>
@@ -3865,7 +3843,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="174,251,69,19" Id="VY07dFv3kzNMy0UhBHKQL3">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\dev\vvvv\vl-libs_22-5\VL.Addons\vl)">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessNode" Name="ModuloGPU" />
                   </p:NodeReference>
@@ -3990,7 +3968,7 @@
                 <ControlPoint Id="DnintNMoEKtNstJuO9F6Dc" Bounds="99,335" />
                 <ControlPoint Id="SJKALEdMddkMdN0GOiSB0n" Bounds="239,98" />
                 <Node Bounds="171,233,69,19" Id="Api3iZOoI4UQJulM7DqHjM">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\dev\vvvv\vl-libs_22-5\VL.Addons\vl)">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessNode" Name="ModuloGPU" />
                   </p:NodeReference>
@@ -4169,7 +4147,7 @@
                   <Pin Id="Vvl4rHCfrbNNkC3vPFJ5CO" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Pad Id="IHVYRL0LSFBNrubONXlgEC" Comment="Profiling Name" Bounds="369,822,132,15" ShowValueBox="true" isIOBox="true" Value="ColorQuadMeshDrawer">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pad>
@@ -4233,7 +4211,7 @@
                       <Pin Id="AYDpRDInBfYNZk7WEyBGyq" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="327,398,316,19" Id="NDoO1nMnlTwLWA3hZPGwPG">
-                      <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="vl">
+                      <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\dev\vvvv\vl-libs_22-5\VL.Addons\vl)">
                         <Choice Kind="ProcessNode" Name="ConstantShader (TextureTransform)" />
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       </p:NodeReference>
@@ -4499,7 +4477,7 @@
                     </Patch>
                   </Node>
                   <Pad Id="Gy1lHCnF8MoNRyr3HmSPWh" Comment="Remote Port" Bounds="230,571,35,15" ShowValueBox="true" isIOBox="true" Value="5858">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Integer32" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -4762,7 +4740,7 @@
             </Node>
             <Link Id="GZJQIof7xq8LNow7V7Dzje" Ids="S7WD9aoBjwhMoHZIfXYNU0,Tjde7PzKxb9OSv2kP75Rxx" />
             <Pad Id="AfJ5Nx0sGwOQLo0L0GxEZh" Comment="" Bounds="267,630,35,43" ShowValueBox="true" isIOBox="true" Value="-1, -1, 1">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
@@ -5166,7 +5144,7 @@
             </Node>
             <Link Id="IrGtE2xLuVHO5NLWCwuVFc" Ids="AAOd1b2VpCPOuIzRxGjJtW,JVYUTifu5myN7Jn2amQyTK" />
             <Pad Id="ATLKy6wfNoVLQbavfRRNlW" Comment="" Bounds="1282,558,35,15" ShowValueBox="true" isIOBox="true" Value="0.5">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
@@ -5413,13 +5391,13 @@
           </p:NodeReference>
           <Patch Id="SlNqrOobPeaObsaImX778u" ManuallySortedPins="true">
             <Pad Id="U0lJ4liz1ANNbvNv4DYBiW" Comment="Aspect" Bounds="264,1540,33,15" ShowValueBox="true" isIOBox="true" Value="1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="Nu27HfMj53GLoAMioHSVpW" Comment="Min" Bounds="302,1013,46,15" ShowValueBox="true" isIOBox="true" Value="-0.249899909">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
@@ -5428,7 +5406,7 @@
               </p:ValueBoxSettings>
             </Pad>
             <Pad Id="NaZtdZAELz9QAv9MslsnUs" Comment="Max" Bounds="322,1035,41,15" ShowValueBox="true" isIOBox="true" Value="0.249900028">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
@@ -5437,13 +5415,13 @@
               </p:ValueBoxSettings>
             </Pad>
             <Pad Id="SayRTuhwzJ9LZQJj4LAmgX" Comment="Scalar" Bounds="243,956,46,15" ShowValueBox="true" isIOBox="true" Value="-1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="RYcC6xIsrx5L6wtSBr4uwg" Bounds="322,1114,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
@@ -6126,7 +6104,7 @@
                   </Node>
                   <Pad Id="Aeo8KZaQcmoL5HckX2UYAi" SlotId="CCjJgL7JciZNn20j33doeY" Bounds="904,677" />
                   <Pad Id="PVJsEWwcDQDMcOqQ7AegrN" Comment="" Bounds="1153,539,74,114" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 0, 0, 0">
-                    <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.Collections.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Spread" />
                       <p:TypeArguments>
                         <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
@@ -9073,7 +9051,7 @@
               <Link Id="NrcmstiIf8GPfHsNwPLpiL" Ids="CFUCPyn85NuL4wYCpgM3ZK,MxkPqzD9k0wOCULvzr7sFh" />
               <Link Id="HBEuQXQztU5O7H01RPT47R" Ids="MxkPqzD9k0wOCULvzr7sFh,TMRlRsdZPXsNu5XGJHciGL" />
               <Pad Id="OirLdcjbfZmOYKkC1O5uv5" Comment="" Bounds="186,142,35,28" ShowValueBox="true" isIOBox="true">
-                <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Vector2" />
                 </p:TypeAnnotation>
               </Pad>
@@ -9160,7 +9138,7 @@
               <Link Id="V76ArlaWfkLNVv4TJuCbaQ" Ids="F2Y1uSloUVVPChRASgibKc,NR4K4EbceSeOnv41BVmJJk" />
               <Link Id="AqvPdU1XQRVQBh5Itjb63s" Ids="UXBnb7OiDGcP5ql6SVEOvO,TW3MQWaHKanNXBRelus8rU" />
               <Pad Id="NIq8iQ8hTX3NJZ6dIqmU6s" Comment="" Bounds="413,138,35,28" ShowValueBox="true" isIOBox="true">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Int2" />
                 </p:TypeAnnotation>
               </Pad>
@@ -9191,7 +9169,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="SeF1XJDWKKVMFCcSlHilsh" Location="VL.Stride" IsFriend="true" Version="2022.5.0-0696-g73767f5671" />
+  <NugetDependency Id="SeF1XJDWKKVMFCcSlHilsh" Location="VL.Stride" IsFriend="true" Version="2022.5.0-0735-ge3039d4101" />
   <PlatformDependency Id="MLVA0izfRMkORdIZzd9kvt" Location="../../../../_vvvv/vvvv_gamma_2022.5.0-0485-g8f46e4a34a/Stride.dll" />
   <PlatformDependency Id="CvdCU2DNQlRMaSdivNSZJy" Location="../../../../_vvvv/vvvv_gamma_2022.5.0-0485-g8f46e4a34a/Stride.Graphics.dll" />
   <PlatformDependency Id="CfSqI9CZTJZLV5hRh33DGP" Location="../../../../_vvvv/vvvv_gamma_2022.5.0-0485-g8f46e4a34a/Stride.Core.dll" />

--- a/vl/VL.Addons.Stride.vl
+++ b/vl/VL.Addons.Stride.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="Cp8BLHoIN3nMQUGZkhFpJw" LanguageVersion="2022.5.0-0485-8f46e4a34a" Version="0.128">
-  <NugetDependency Id="GFBaA1xQ5F2NjgUCO9vziQ" Location="VL.CoreLib" Version="2022.5.0-0485-g8f46e4a34a" />
+<Document xmlns:p="property" Id="Cp8BLHoIN3nMQUGZkhFpJw" LanguageVersion="2022.5.0-0696-g73767f5671" Version="0.128">
+  <NugetDependency Id="GFBaA1xQ5F2NjgUCO9vziQ" Location="VL.CoreLib" Version="2022.5.0-0696-g73767f5671" />
   <Patch Id="VeJSap7sIKJNwnBokjEoI8">
     <Canvas Id="KAeiw0WXEdQNQT9FSe5ubO" DefaultCategory="Stride" CanvasType="FullCategory">
       <Canvas Id="La2rwazVWI1LNRD2Wi4LG0" Name="Graphics" Position="298,128">
@@ -10,89 +10,89 @@
 
 -->
         <Node Name="ImageDescription" Category="Stride.Graphics.ImageDescription" Bounds="82,426,273,488" Id="Im4cXcSmw7QOd8P3gA1BzP">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="QZyFny6m85eNzafkzXhOPn">
             <Node Bounds="94,731,79,26" Id="S9fF60b1uUpLaIhi5emMrB">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="SetFormat" />
               </p:NodeReference>
               <Pin Id="Oqa7bSZPoOvQInDHFxVKPJ" Name="Input" Kind="StateInputPin" />
               <Pin Id="GzqkMiU3HosNgO3I1r11rw" Name="Value" Kind="InputPin" DefaultValue="R8G8B8A8_UNorm">
-                <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.vl">
                   <Choice Kind="TypeFlag" Name="PixelFormat" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="JRJMLi14So6NK5u5f595Zn" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="94,679,79,26" Id="QlnYyV0pdxhOAiDIf9oQ3K">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="SetHeight" />
               </p:NodeReference>
               <Pin Id="JH6RAjPpFmxOU7DajC2Uqf" Name="Input" Kind="StateInputPin" />
               <Pin Id="T6BJWWO1nRdNId8Z5f1Ols" Name="Value" Kind="InputPin" DefaultValue="512">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="PnyBUnI18YOMxIsaZkXsnS" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="94,628,79,26" Id="L9QqiC9thIkPUXgohcnuDy">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="SetWidth" />
               </p:NodeReference>
               <Pin Id="Q2T94pAHoCKQE1Z4NKMllo" Name="Input" Kind="StateInputPin" />
               <Pin Id="AqYYDyLbqqhLHDt9bdR2kh" Name="Value" Kind="InputPin" DefaultValue="512">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QKGQY387QQbMCckn96AJDg" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="95,468,79,26" Id="QTRPBYXiXgJNMBMvUnlBh0">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="SetDimension" />
               </p:NodeReference>
               <Pin Id="A3eyfQgsHwpOZKvYDWnjjQ" Name="Input" Kind="StateInputPin" />
               <Pin Id="CfVSVNQDYSBOBJqxwjBZhF" Name="Value" Kind="InputPin" DefaultValue="Texture2D">
-                <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.dll">
+                <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.dll">
                   <Choice Kind="TypeFlag" Name="TextureDimension" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Ua3EzLvnDEoOCk55gu7U1d" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="94,566,95,26" Id="VBDzaDnBE6hPWaewjGKnLF">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="SetDepth" />
               </p:NodeReference>
               <Pin Id="AmFuNoDky2dP4bF2VIq83H" Name="Input" Kind="StateInputPin" />
               <Pin Id="MbCQ6qqjjgtP3iVGZeONob" Name="Value" Kind="InputPin" DefaultValue="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CD7U51u5x89Mo5WnG5JYLy" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="94,789,79,26" Id="DOG0Viiew7VMtimain5PUc">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="SetMipLevels" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" NeedsToBeDirectParent="true" />
               </p:NodeReference>
               <Pin Id="CMkT1msLzVCMvyQPvvuWq0" Name="Input" Kind="StateInputPin" />
               <Pin Id="KsLWuQhHpNmOpdQWbGddee" Name="Value" Kind="InputPin" DefaultValue="0">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -105,14 +105,14 @@
             <Link Id="UBtrGw99twGLFdDJ9jxVuQ" Ids="GfsK3BA7qDaP6ukuZCk6vM,MbCQ6qqjjgtP3iVGZeONob" />
             <Link Id="AiU6Dkeu7frOF1P3i1ZDLW" Ids="SCSBd3906iVQb9V2go2TMb,GfsK3BA7qDaP6ukuZCk6vM" IsHidden="true" />
             <Pad Id="IZA5acR74bhMG9slb1b2tX" Comment="" Bounds="171,454,87,15" ShowValueBox="true" isIOBox="true" Value="Texture2D">
-              <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.dll">
+              <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.dll">
                 <Choice Kind="TypeFlag" Name="TextureDimension" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="BjmAg49BESZPWZO4gDpZ0P" Ids="IZA5acR74bhMG9slb1b2tX,CfVSVNQDYSBOBJqxwjBZhF" />
             <Link Id="TTIyLI5srXeOC3RIJRjf4W" Ids="CD7U51u5x89Mo5WnG5JYLy,Q2T94pAHoCKQE1Z4NKMllo" />
             <Node Bounds="200,565,36,19" Id="AWxil5k2mtVMTihB3GKtQF">
-              <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="Int2" />
                 <Choice Kind="OperationCallFlag" Name="Int2 (Split)" />
@@ -135,14 +135,14 @@
             <ControlPoint Id="VoPlifOzNjqOE9wAXk1W1D" Bounds="96,897" />
             <Link Id="TpYhGwrkbiUQXK6O0YA4xi" Ids="VoPlifOzNjqOE9wAXk1W1D,SMs0CicVJLnOPcfdcBbSnG" IsHidden="true" />
             <Node Bounds="94,845,80,26" Id="Q7IPAbTonXKLRxqyisfbvH">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="SetArraySize" />
               </p:NodeReference>
               <Pin Id="DsNsNXZGmxLQFDM3ahgDBM" Name="Input" Kind="StateInputPin" />
               <Pin Id="BEkzzoBUdpyNyWFeUn5vbm" Name="Value" Kind="InputPin" DefaultValue="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -156,7 +156,7 @@
             <Link Id="HWPk215TBWRNnpvFs1lO0X" Ids="Ua3EzLvnDEoOCk55gu7U1d,AmFuNoDky2dP4bF2VIq83H" />
             <Pin Id="SCSBd3906iVQb9V2go2TMb" Name="Depth" Kind="InputPin" Bounds="476,232" Visibility="Optional" />
             <Pin Id="Hqp4XmRVxlnMksHSw9KydW" Name="Size" Kind="InputPin" Bounds="537,225" DefaultValue="512, 512">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Int2" />
               </p:TypeAnnotation>
             </Pin>
@@ -172,13 +172,13 @@
 
 -->
         <Node Name="FileImage" Category="Stride.Graphics.Image" Bounds="84,343" Id="AcOqgHVGziAN3rZiNCOHK5">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="Rsn4PJDG7gDOUrDExPNkC8">
             <Canvas Id="EbTasmafWMnM8mcFUO1oH9" CanvasType="Group">
               <Node Bounds="124,128,216,128" Id="PKQVxvmqj48LSKt3d9o9PJ">
-                <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="System.Resources" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationCallFlag" Name="Using (Select)" />
                   <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                 </p:NodeReference>
@@ -190,7 +190,7 @@
                   <ControlPoint Id="IDYmK5lRBtzPJWij6wurTU" Bounds="138,159" />
                   <ControlPoint Id="T2MHtrXKOa8O8g8wGdrWTF" Bounds="138,249" />
                   <Node Bounds="136,205,38,19" Id="LqSpnW3EPmHOQHeII5ka7q">
-                    <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastSymbolSource="Stride.dll">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastDependency="Stride.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Image" />
                       <Choice Kind="OperationCallFlag" Name="Load" />
@@ -201,25 +201,25 @@
                     <Pin Id="DuRHSpM3dD3OlDSOfcrVpk" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Pad Id="Mihku1irHW3PFb0pEF6G84" Comment="Load As SRGB" Bounds="209,156,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pad>
                 </Patch>
               </Node>
               <Node Bounds="124,87,65,19" Id="Th8vXSiSbJXLzv0aqCNwGu">
-                <p:NodeReference LastCategoryFullName="IO" LastSymbolSource="VL.CoreLib.IO.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="File" />
                   <CategoryReference Kind="Category" Name="IO" NeedsToBeDirectParent="true" />
                 </p:NodeReference>
                 <Pin Id="USrO0fUOUUyNhuxRaXlFu4" Name="File Path" Kind="InputPin" DefaultValue="..\..\..\Users\paranoiduser\Downloads\_Content_2018\_Previews\Gold\11635 - Bette GmbH &amp; Co. KG\11635-1.jpg">
-                  <p:TypeAnnotation LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Path" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="OLXyUkuBsyfLZFqoolw075" Name="File Mode" Kind="InputPin" DefaultValue="Open">
-                  <p:TypeAnnotation LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="FileMode" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -261,12 +261,12 @@
 
 -->
         <Node Name="Split" Category="Stride.Graphics.ImageDescription" Bounds="465,428,160,410" Id="U8dl9njFIVqPHQI3NXGH50">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="KRO3qisUb1qMbcIbjiV5N1">
             <Node Bounds="477,469,79,26" Id="AvhmNnjfcmGO2EixYmp1RI">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="ArraySize" />
@@ -276,7 +276,7 @@
               <Pin Id="JwprqnWQAV4P6T8TWqan3Q" Name="Array Size" Kind="OutputPin" />
             </Node>
             <Node Bounds="477,516,79,26" Id="PfSeUiHxVusQCr8RMlfmmt">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="Depth" />
@@ -286,7 +286,7 @@
               <Pin Id="T8qgtLvnKW5LzhhohyP735" Name="Depth" Kind="OutputPin" />
             </Node>
             <Node Bounds="477,563,79,26" Id="CtbrI3ohrGPMnS6NNwI8Sv">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="Dimension" />
@@ -296,7 +296,7 @@
               <Pin Id="O6nL40ISd9WOUC0fGvncq0" Name="Dimension" Kind="OutputPin" />
             </Node>
             <Node Bounds="477,610,79,26" Id="RLx8W7Sk9yaN1g9MLvvkbs">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="Format" />
@@ -306,7 +306,7 @@
               <Pin Id="LGMw59whbFHPjIxfo2b0TA" Name="Format" Kind="OutputPin" />
             </Node>
             <Node Bounds="477,657,79,26" Id="Qp0coOY7qb1OEVsUWeJpzW">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="MipLevels" />
@@ -316,7 +316,7 @@
               <Pin Id="GbmsuuTqVu2NXFM9yVWtzC" Name="Mip Levels" Kind="OutputPin" />
             </Node>
             <Node Bounds="477,738,79,26" Id="G0gtkX50D0RNETSLRrp8gu">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="Width" />
@@ -326,7 +326,7 @@
               <Pin Id="TSGBPwomOGJPH3x59t8FyE" Name="Width" Kind="OutputPin" />
             </Node>
             <Node Bounds="477,701,79,26" Id="ChOC1lZSIOpL7l2BRY9yVS">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                 <Choice Kind="OperationCallFlag" Name="Height" />
@@ -367,7 +367,7 @@
             <Pin Id="KGz3rN7olPALEHQB38Huv1" Name="Mip Levels" Kind="OutputPin" Bounds="945,661" />
             <Link Id="Jdzq4eAx4TaNIBqzIS0ThE" Ids="CHqW9cbITsfP0FwuIqf9RP,KGz3rN7olPALEHQB38Huv1" IsHidden="true" />
             <Node Bounds="551,773,46,19" Id="LlQdNL4oA4aOmxCUqJb5Y3">
-              <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="Int2" />
                 <Choice Kind="OperationCallFlag" Name="Int2 (Create)" />
@@ -393,7 +393,7 @@
 
 -->
         <Node Name="Info" Category="Stride.Graphics.PixelBuffer" Bounds="461,346" Id="BGS5wzDte9jLm3VTLxyxOQ">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="PIowCHaOio7L8gcEKRAwT9">
@@ -404,7 +404,7 @@
               <ControlPoint Id="NMlNOvbDxT3QMnOfXLkYdr" Bounds="206,449" />
               <ControlPoint Id="TRKIISviqlEPElbuKVBAtY" Bounds="173,472" />
               <Node Bounds="104,144,177,256" Id="GwkbuelWwLFLrvmeI8W7lJ">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <FullNameCategoryReference ID="Primitive" />
@@ -422,7 +422,7 @@
                   <Patch Id="S54QoOCM23kPjOseFFKZek" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="OB8rEcPJrD7PKpkWj0AAXU" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="116,223,55,26" Id="TiWl6wZosRwQaAGZv0vTSL">
-                    <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastSymbolSource="Stride.dll">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastDependency="Stride.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="PixelBuffer" />
                       <Choice Kind="OperationCallFlag" Name="Height" />
@@ -432,7 +432,7 @@
                     <Pin Id="Ml4lrpwBGMtPVDcJrGSt9S" Name="Height" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="116,268,55,26" Id="NxNjaWoxorJMBKprwqZmh6">
-                    <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastSymbolSource="Stride.dll">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastDependency="Stride.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="PixelBuffer" />
                       <Choice Kind="OperationCallFlag" Name="Width" />
@@ -442,7 +442,7 @@
                     <Pin Id="BUMCBSmcu6CMibx8v9SsRz" Name="Width" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="116,349,61,26" Id="R1chWsthUwPPHhBynxmDIv">
-                    <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastSymbolSource="Stride.dll">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastDependency="Stride.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="PixelBuffer" />
                       <Choice Kind="OperationCallFlag" Name="RowStride" />
@@ -452,7 +452,7 @@
                     <Pin Id="CPEciyzCXnaNkbcugnE1g9" Name="Row Stride" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="116,167,55,26" Id="M5b1KCSTharPGaTPmwqHfi">
-                    <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastSymbolSource="Stride.dll">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastDependency="Stride.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="PixelBuffer" />
                       <Choice Kind="OperationCallFlag" Name="Format" />
@@ -462,7 +462,7 @@
                     <Pin Id="AnpGwjhsxh1PSFwsyBUZtF" Name="Format" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="166,309,46,26" Id="JeqaunQN7yCOGui6n0XF6M">
-                    <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Int2" />
                       <Choice Kind="OperationCallFlag" Name="Create" />
@@ -476,7 +476,7 @@
                 </Patch>
               </Node>
               <Node Bounds="104,98,65,19" Id="ECxCQXa0AZaMgz678wJhH2">
-                <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                 </p:NodeReference>
@@ -526,7 +526,7 @@
           </Patch>
         </Node>
         <Pad Id="PNRRufgMWA2P8kYzZz1oQf" Bounds="80,297,177,19" ShowValueBox="true" isIOBox="true" Value="Loads image from file">
-          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
             <Choice Kind="TypeFlag" Name="String" />
           </p:TypeAnnotation>
           <p:ValueBoxSettings>
@@ -540,14 +540,14 @@
 
 -->
         <Node Name="Split" Category="Stride.Graphics.TextureDescription" Bounds="835,426,205,609" Id="L28m7GhGShkLoRQBLZfhxX">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="TvLAfgGQTSEMv3nyALS8Lk" ManuallySortedPins="true">
             <ControlPoint Id="MeeBlWJEwhfPotaH4qZB9H" Bounds="850,444" />
             <Link Id="FOBGNyQKstHLdDN5IjwriX" Ids="Fr6U8a3Jiw4OqHj22yAIYL,MeeBlWJEwhfPotaH4qZB9H" IsHidden="true" />
             <Node Bounds="886,474,85,26" Id="UyvOMmkbRqrMYfq9TuHbhO">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" />
                 <Choice Kind="OperationCallFlag" Name="ArraySize" />
@@ -557,7 +557,7 @@
             </Node>
             <Link Id="J6MOmiotezYNVKorig3Upd" Ids="MeeBlWJEwhfPotaH4qZB9H,THMOV8jmUqEQG1OK9hI5G4" />
             <Node Bounds="886,531,85,26" Id="SIZYlaOt6xKM881DIuVVJr">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" />
                 <Choice Kind="OperationCallFlag" Name="Depth" />
@@ -566,7 +566,7 @@
               <Pin Id="CI2c4c5aPb7LLz1tACyXIb" Name="Depth" Kind="OutputPin" />
             </Node>
             <Node Bounds="886,588,85,26" Id="TI0Ef5PX0XHL9eLQ8KcDeE">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" />
                 <Choice Kind="OperationCallFlag" Name="Dimension" />
@@ -575,7 +575,7 @@
               <Pin Id="FrXy0nJmXzUO3wJDAKzmtC" Name="Dimension" Kind="OutputPin" />
             </Node>
             <Node Bounds="886,645,85,26" Id="LDmG4FxOARoLoTDSdzb7SR">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" />
                 <Choice Kind="OperationCallFlag" Name="Flags" />
@@ -584,7 +584,7 @@
               <Pin Id="UdQPiSms6wBNcL6Ctpobp9" Name="Flags" Kind="OutputPin" />
             </Node>
             <Node Bounds="886,702,85,26" Id="Qkn2FhCxwLlNZWYn3f2RG2">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" />
                 <Choice Kind="OperationCallFlag" Name="Format" />
@@ -593,7 +593,7 @@
               <Pin Id="URz3bme7ycrMv7pKMUFmk5" Name="Format" Kind="OutputPin" />
             </Node>
             <Node Bounds="886,759,85,26" Id="GKJEgdzWDmgN5dKidnamg2">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" />
                 <Choice Kind="OperationCallFlag" Name="MipLevels" />
@@ -602,7 +602,7 @@
               <Pin Id="ODRIkc2AwPHMmnaUyVL59X" Name="Mip Levels" Kind="OutputPin" />
             </Node>
             <Node Bounds="886,816,85,26" Id="BpBKlptI54dPYuRC4bkpHc">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" />
                 <Choice Kind="OperationCallFlag" Name="Height" />
@@ -611,7 +611,7 @@
               <Pin Id="Ru4ESzGsULuM1v0xSvHt4D" Name="Height" Kind="OutputPin" />
             </Node>
             <Node Bounds="886,873,85,26" Id="CLLdZQAalDHPgaSEhFtZdK">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" />
                 <Choice Kind="OperationCallFlag" Name="Width" />
@@ -620,7 +620,7 @@
               <Pin Id="CiV7D6NUXwXL2QDyH7MilW" Name="Width" Kind="OutputPin" />
             </Node>
             <Node Bounds="886,966,85,26" Id="J9BJwvFreuONlVLtwKnG5P">
-              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" />
                 <Choice Kind="OperationCallFlag" Name="Usage" />
@@ -647,7 +647,7 @@
             <Link Id="I8sCWzrYQ1fNxB7OBKjsZ5" Ids="ODRIkc2AwPHMmnaUyVL59X,KYblZ41srH1La6W2i2Xc27" />
             <Link Id="MRMynOiVI4dL1UZgr32FQe" Ids="KYblZ41srH1La6W2i2Xc27,RGnoRE9J6ZPLvIUKcd8VCw" IsHidden="true" />
             <Node Bounds="966,916,46,19" Id="AArMwMQYC30N75pS5u4bxd">
-              <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="Int2" />
                 <Choice Kind="OperationCallFlag" Name="Int2 (Create)" />
@@ -700,13 +700,13 @@
 
 -->
             <Node Name="FromFiles" Bounds="85,99" Id="J2NgDCpb6uKO1CGFVR79WC">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="I6BNBlTxf5uOFqkam6OIv2">
                 <Canvas Id="BXf6sK4vLeJOQPkX6qbXl2" CanvasType="Group">
                   <Node Bounds="119,110,84,86" Id="CIIEYcn7vF2NKTyRsSXfKE">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <FullNameCategoryReference ID="Primitive" />
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -720,7 +720,7 @@
                       <Patch Id="ROtEvwlXiJ5N9S2P7Y9G12" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="HqlTi0Ri191MPguAmNdU3F" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="131,143,60,19" Id="BZQXTrOw0VlNMbVv8H9uvq">
-                        <p:NodeReference LastCategoryFullName="Stride.Textures.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FromFiles" />
                           <PinReference Kind="InputPin" Name="Load As SRGB" />
@@ -732,7 +732,7 @@
                     </Patch>
                   </Node>
                   <Pad Id="RjKTRtOgEycNIKApmSbo8s" Comment="Dispose Cached Outputs" Bounds="200,103,35,15" ShowValueBox="true" isIOBox="true" Value="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -770,13 +770,13 @@
 
 -->
             <Node Name="FromTextures" Bounds="84,160" Id="Qbx4e9WlRH1L6bW7uOxcwZ">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="DmCndgqv8F7QQiQ33FRMjg">
                 <Canvas Id="FEmXS9dlaHnPmQXXwG7psN" CanvasType="Group">
                   <Node Bounds="71,117,104,86" Id="KqlYulgrTewMCtK9424z8s">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <FullNameCategoryReference ID="Primitive" />
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -790,7 +790,7 @@
                       <Patch Id="GjvC6V44RFuN8yxy9Ma5nC" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="UutkJvhg4IIP9e5LCbcFJp" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="83,153,80,19" Id="QAVa2JI1WoILTGpyQcftUf">
-                        <p:NodeReference LastCategoryFullName="Stride.Textures.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FromTextures" />
                         </p:NodeReference>
@@ -800,12 +800,12 @@
                     </Patch>
                   </Node>
                   <Pad Id="FsA99bl9NBKLhZZiCkEmVs" Comment="Dispose Cached Outputs" Bounds="172,83,35,24" ShowValueBox="true" isIOBox="true" Value="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Pad Id="RsongeA3MY7NoFGSRjN1nW" Bounds="174,54,58,19" ShowValueBox="true" isIOBox="true" Value="I guess?">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                     <p:ValueBoxSettings>
@@ -843,13 +843,13 @@
 
 -->
             <Node Name="FromTextures (Async)" Bounds="82,221" Id="R5VI5yBNahyO3mbIDMuDy3">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="Vire99VIRu1O3QmGfk9XeD">
                 <Canvas Id="DLXkzvr53XVLlwW7YSvpG5" CanvasType="Group">
                   <Node Bounds="98,102,104,83" Id="QH0Kv4J8drAMtAk8TLvFll">
-                    <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="ProcessAppFlag" Name="AsyncTask" />
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     </p:NodeReference>
@@ -866,7 +866,7 @@
                       <ControlPoint Id="NPPbyNSSSpoOS8avkKO587" Bounds="103,110" />
                       <ControlPoint Id="T7hBadtMuPfPxsAUjpQVml" Bounds="112,178" />
                       <Node Bounds="110,141,80,19" Id="MM3s78xrWtMLgDZdHdLlwF">
-                        <p:NodeReference LastCategoryFullName="Stride.Textures.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FromTextures" />
                         </p:NodeReference>
@@ -878,7 +878,7 @@
                   <ControlPoint Id="IoN1w5mD4X0OYGxpWWOQDr" Bounds="113,74" />
                   <ControlPoint Id="ARLBELbrHTTO5rfiTOO1xB" Bounds="70,5" />
                   <Node Bounds="98,217,65,19" Id="CUjysCWkQIeNvqex4yEGm1">
-                    <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
                     </p:NodeReference>
@@ -890,7 +890,7 @@
                   <ControlPoint Id="BD1DrRJZi9OPnHCXvayVzX" Bounds="100,365" />
                   <ControlPoint Id="VBSwR56u4dLP1l8F8I9EK0" Bounds="160,255" />
                   <Node Bounds="97,38,69,19" Id="JaWAnE5LALtNVcqdPXKqGo">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="FrameDelay" />
                     </p:NodeReference>
@@ -898,7 +898,7 @@
                     <Pin Id="Tj4aOHTHWaIOk2vlKRNoAs" Name="Value" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="86,272,77,68" Id="JQBdVzl3AmiMnS4YsKltMX">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -908,7 +908,7 @@
                       <Patch Id="G3139sIqZOUPWBGohMBu3l" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="OySSbQBEpcxOVgtQCIk0fy" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="98,301,53,19" Id="BR07PIAz50pLyNsAtyzvzc">
-                        <p:NodeReference LastCategoryFullName="Stride.Core.Utilities" LastSymbolSource="Stride.Core.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Core.Utilities" LastDependency="Stride.Core.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Dispose" />
                           <CategoryReference Kind="AssemblyCategory" Name="Utilities" NeedsToBeDirectParent="true">
@@ -923,7 +923,7 @@
                   </Node>
                   <ControlPoint Id="KB3CSHETDk8P4E3XffI3y9" Bounds="71,218" />
                   <Pad Id="ElyM1bb2NZoLbSxRm41ZvJ" Bounds="163,305,47,19" ShowValueBox="true" isIOBox="true" Value="mmh?">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                     <p:ValueBoxSettings>
@@ -968,7 +968,7 @@
 
 -->
             <Node Name="FromTextures (Internal)" Bounds="489,159" Id="GVxhTcTFogfLw4kesnK1dV">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="FcECxa9o1H5QPpeIGqRjYR">
@@ -979,12 +979,12 @@
 
 -->
                   <Node Name="New2D (Internal)" Bounds="1031,174,457,223" Id="FlMdAZ0fzLqOsXJdkicSu7">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                       <Choice Kind="OperationDefinition" Name="Operation" />
                     </p:NodeReference>
                     <Patch Id="Dbj5xpO1X2EOL2vVufAVry" ManuallySortedPins="true">
                       <Node Bounds="1043,320,267,19" Id="VdS6OYmfH2sOsBtHbDY4w9">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
                           <PinReference Kind="InputPin" Name="Mip Count" />
@@ -1002,7 +1002,7 @@
                         <Pin Id="SRfqj1pF9PsNwkEPMdsUMX" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1076,240,345,19" Id="FylLRl67ur6QC06iGZezBr">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
                           <CategoryReference Kind="RecordType" Name="TextureDescription" NeedsToBeDirectParent="true">
@@ -1030,7 +1030,7 @@
                       <Pin Id="FjbVPPjmQLEQRZ0Sc2Wgot" Name="Device" Kind="InputPin" Bounds="1150,1802" />
                       <Link Id="Nw5p558BafLP0ErWDFPu5H" Ids="FjbVPPjmQLEQRZ0Sc2Wgot,VxEvmZON91gN8BtjsbsO70" IsHidden="true" />
                       <Node Bounds="1076,276,38,26" Id="OaKpWlEpx6dMuF3EkVLcwS">
-                        <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="Int2" />
                           <Choice Kind="OperationCallFlag" Name="Int2 (Split)" />
@@ -1043,7 +1043,7 @@
                       <Link Id="TmrwPQFFm0zMPblnkeikwp" Ids="GKmk6gFkAXDORbSFHXz6zq,H3dNZ1AGpG8LQ0yZrZ0bHw" />
                       <Link Id="ORVv5acpXpBON42X5voNfa" Ids="BVUBwNTErj1OwTYxxwMaqY,BOAiA4LjVN1OOo8EOj2A8s" />
                       <Node Bounds="1141,280,66,26" Id="SRjHG1SphKlQGodLDoklfy">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.MipMapCount" LastSymbolSource="Stride.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.MipMapCount" LastDependency="Stride.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="AssemblyCategory" Name="MipMapCount" />
                           <Choice Kind="OperationCallFlag" Name="Create" />
@@ -1060,13 +1060,13 @@
                       <Pin Id="Ga6ENIRkkCSNtL8xR0ZUhU" Name="Array Size" Kind="InputPin" Bounds="1346,1785" />
                       <Link Id="IR9xlkSSyPIPa8N7BUsYu6" Ids="Ga6ENIRkkCSNtL8xR0ZUhU,QTJMpJ317akNTJDltDiD8P" IsHidden="true" />
                       <Pad Id="KMYfkrVXFGHNjMtzzk8aAn" Comment="Texture Flags" Bounds="1209,282,128,15" ShowValueBox="true" isIOBox="true" Value="ShaderResource">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.Graphics.dll">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="TypeFlag" Name="TextureFlags" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Link Id="CPEWaVfw0VLLVK7fyDfTWM" Ids="KMYfkrVXFGHNjMtzzk8aAn,LHc9laO1Hi9QMentWvMMAa" />
                       <Pad Id="GtxxE6JB1bbOBxg6icTLaz" Comment="Usage" Bounds="1274,299,77,15" ShowValueBox="true" isIOBox="true" Value="Default">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.Graphics.dll">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="TypeFlag" Name="GraphicsResourceUsage" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -1080,7 +1080,7 @@
                   <ControlPoint Id="A0h2Sbz90EeMXDRpNd3e9F" Bounds="229,33" />
                   <ControlPoint Id="HaY5TEKYOWcMzQ7Lr8NxiZ" Bounds="460,1184" />
                   <Node Bounds="77,129,824,1030" Id="BM2KgY0JQtiM6YjfoQA2dK">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -1096,7 +1096,7 @@
                       </Patch>
                       <Patch Id="BkxBWSkWrmRMrQMfUqcRLC" Name="Dispose" ManuallySortedPins="true" />
                       <Node Bounds="228,153,111,26" Id="Nc7DaZOVJhHNmISKLOTshf">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Description" />
                           <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -1106,7 +1106,7 @@
                         <Pin Id="Oi9kaRi8u9rPGWwRBY4kIh" Name="Description" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="482,200,85,26" Id="ONJvFPMKAUkOxiJYoEKRLE">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ArraySize" />
                           <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -1115,7 +1115,7 @@
                         <Pin Id="L9orCiTv6pBOEZrluqJUwc" Name="Array Size" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="408,236,85,26" Id="IcRCUzuda26LML0Qp0tHIX">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Dimension" />
                           <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -1124,25 +1124,25 @@
                         <Pin Id="SMHNaPFYsUPOkLmLgyOp80" Name="Dimension" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="482,311,25,19" Id="Chvuml33BTYMw7fHumOsoW">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="=" />
                         </p:NodeReference>
                         <Pin Id="NgkmnS9CFgzNPnA4P4FXO3" Name="Input" Kind="InputPin" />
                         <Pin Id="HaKrJy6ja9RLAHKoqLCBRK" Name="Input 2" Kind="InputPin" DefaultValue="1">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Integer32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="BORaK8KXaUlOvIQrw1V6lY" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="Nh8fdA4bJLLQM2WFpPvrx4" Comment="" Bounds="430,274,87,15" ShowValueBox="true" isIOBox="true" Value="Texture2D">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.dll">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.dll">
                           <Choice Kind="TypeFlag" Name="TextureDimension" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Node Bounds="408,311,25,19" Id="Vme2SIQnsytPABdshMrExP">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDimension" LastSymbolSource="Stride.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDimension" LastDependency="Stride.dll">
                           <CategoryReference Kind="AssemblyCategory" Name="TextureDimension" />
                           <Choice Kind="OperationCallFlag" Name="=" />
                         </p:NodeReference>
@@ -1151,12 +1151,12 @@
                         <Pin Id="F5tXy1PanI6PkLg2fTP4D2" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="BrWYP7jBdiVP4VLIdGAHsl" Comment="" Bounds="504,293,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="Integer32" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Node Bounds="408,341,79,19" Id="V2XrcVjB0aqLyX2LBgPhVm">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                           <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
@@ -1166,7 +1166,7 @@
                         <Pin Id="OGoiIHvQCCwPs8V2xTNziU" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="100,401,789,725" Id="CfNVpqbWs6FNCmdnR9qrVm">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
@@ -1182,7 +1182,7 @@
                           <Patch Id="DCMEtERSW8hOSm4iAdGWqe" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="V5VIuhcdDxgQHaWhMU7yDq" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="217,477,576,160" Id="MrZtXnaEPl5QFDJ4Xp5AAh">
-                            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ApplicationStatefulRegion" Name="If" />
                               <FullNameCategoryReference ID="Primitive" />
@@ -1200,7 +1200,7 @@
                               <Patch Id="L7ep12xd7NQOCYoh1QuH3N" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="K9PLTdcQ9B4OyLcCQnHHgx" Name="Then" ManuallySortedPins="true" />
                               <Node Bounds="457,569,324,19" Id="C4M6ymgZ2ByMZkuEbh3mrC">
-                                <p:NodeReference LastCategoryFullName="Stride.Textures.TextureArray.FromTextures" LastSymbolSource="VL.Addons.Stride.vl">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray.FromTextures" LastDependency="VL.Addons.Stride.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="New2D" />
                                   <CategoryReference Kind="Category" Name="FromTextures" NeedsToBeDirectParent="true" />
@@ -1213,7 +1213,7 @@
                             </Patch>
                           </Node>
                           <Node Bounds="157,446,65,19" Id="LSDBrtSFmImLFvJjFrbzNE">
-                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                             </p:NodeReference>
@@ -1222,7 +1222,7 @@
                             <Pin Id="Qikl2Fdwq5jPbko5bwexRO" Name="Not Assigned" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="192,716,661,373" Id="Mw1ovlG664ZLk62Gj0tTFJ">
-                            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <CategoryReference Kind="Category" Name="Primitive" />
                               <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
@@ -1243,7 +1243,7 @@
                               <Patch Id="UgYVfY4jeEwO2gJNoNdpv9" Name="Dispose" ManuallySortedPins="true" />
                               <ControlPoint Id="DG8vXfa2xZgOZniqElZ7gK" Bounds="661,791" />
                               <Node Bounds="215,887,562,163" Id="P6ANmIGJSDtLyiILcMJ1Dh">
-                                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                                   <FullNameCategoryReference ID="Primitive" />
@@ -1257,7 +1257,7 @@
                                   <Patch Id="QdvzYAczRWKOLLIxEX0BaM" Name="Create" ManuallySortedPins="true" />
                                   <Patch Id="JRl7Y6H36zSMixxrvL0ZRL" Name="Then" ManuallySortedPins="true" />
                                   <Node Bounds="249,979,516,26" Id="PWnlxnghe93NN1Ed4LqmrG">
-                                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.CommandList" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.CommandList" LastDependency="VL.Stride.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="OperationCallFlag" Name="CopyRegion" />
                                     </p:NodeReference>
@@ -1275,12 +1275,12 @@
                                 </Patch>
                               </Node>
                               <Pad Id="VzXYJAIu3IlMOMz1WPbMwV" Comment="" Bounds="217,851,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                                   <Choice Kind="TypeFlag" Name="Boolean" />
                                 </p:TypeAnnotation>
                               </Pad>
                               <Node Bounds="228,807,153,26" Id="IeSL4gHcfwjQVJ0z1wnOuI">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="GetSubResourceIndex" />
                                   <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -1292,7 +1292,7 @@
                                 <Pin Id="S74DB3DHLuZQZt0pPVXYxM" Name="Result" Kind="OutputPin" />
                               </Node>
                               <Node Bounds="457,804,115,26" Id="GCHHSPiOitJPun7SoYOrtW">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="GetSubResourceIndex" />
                                   <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -1306,7 +1306,7 @@
                             </Patch>
                           </Node>
                           <Node Bounds="335,650,85,26" Id="SNBCUZrQeb1NgaxqKvSS5Z">
-                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="MipLevels" />
                               <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -1320,7 +1320,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="850,43,92,19" Id="HtX0tSOBvPUPp9tJU0KvrU">
-                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="GraphicsContext" />
                       <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -1330,7 +1330,7 @@
                     <Pin Id="Eu1vtjyv8FdOzgw1kplzOV" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="850,76,79,26" Id="IGjt1IhGCjeNw48rgGGxmx">
-                    <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsContext" LastSymbolSource="Stride.Graphics.dll">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsContext" LastDependency="Stride.Graphics.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="GraphicsContext" />
                       <Choice Kind="OperationCallFlag" Name="CommandList" />
@@ -1340,7 +1340,7 @@
                     <Pin Id="MKuEAyP1or7NGE0wTNm8nQ" Name="Command List" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="646,77,86,19" Id="OLdhvIOEpwDPqosqmKStH5">
-                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="GraphicsDevice" />
                       <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -1350,7 +1350,7 @@
                     <Pin Id="PFwmL5lQZSXNErKCji06Xl" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="779,73,44,26" Id="KrjbfmTJuyNNq4HGecYuq2">
-                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Count" />
                       <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -1451,13 +1451,13 @@
 
 -->
             <Node Name="FromFiles (Internal)" Bounds="486,99" Id="TN2iQpPJVBmM9qEAGYJfbG">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="V6nVdkO0UnMQLiWZTbU233">
                 <Canvas Id="ECjRzIOl6OFOj6AElR6rlJ" CanvasType="Group">
                   <Node Bounds="443,85,44,26" Id="VTJEnGMv0NNMNxsaRVYH3L">
-                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Count" />
                       <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -1468,7 +1468,7 @@
                   <ControlPoint Id="LOYi5Bo8EnNNHxhzGEXGuC" Bounds="445,44" />
                   <ControlPoint Id="GSzHBKVSNgPMKWuiIok9CH" Bounds="290,41" />
                   <Node Bounds="85,125,657,1024" Id="BLDtADZr7EJM36lata1qrQ">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -1484,7 +1484,7 @@
                       </Patch>
                       <Patch Id="GjG72CKDN9HNKfLkYDouvN" Name="Dispose" ManuallySortedPins="true" />
                       <Node Bounds="233,183,113,26" Id="KrUkiPRZG26OFP2emDVQiQ">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastSymbolSource="Stride.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastDependency="Stride.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="AssemblyCategory" Name="Image" />
                           <Choice Kind="OperationCallFlag" Name="Description" />
@@ -1494,7 +1494,7 @@
                         <Pin Id="IjI2XNG6jEVP5xNmPRnTTv" Name="Description" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="341,225,153,26" Id="AAz31dOCZYdOdPgbLszyA6">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                           <Choice Kind="OperationCallFlag" Name="ArraySize" />
@@ -1504,7 +1504,7 @@
                         <Pin Id="HIopZJyV6yrN4TWbWGxAU4" Name="Array Size" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="341,303,79,26" Id="C7kHSeXWubNMy1DMvgXsV3">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                           <Choice Kind="OperationCallFlag" Name="Dimension" />
@@ -1514,25 +1514,25 @@
                         <Pin Id="Ryo6cOXdJJzOveNNOhDgNi" Name="Dimension" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="489,283,25,19" Id="Lc65qbtX04sL2Id50nSgeh">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="=" />
                         </p:NodeReference>
                         <Pin Id="FxxQVGz3UpKO2noVPveQI0" Name="Input" Kind="InputPin" />
                         <Pin Id="HzlnNqczyknMMtqv4iSZAx" Name="Input 2" Kind="InputPin" DefaultValue="1">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Integer32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="LQrik3qCJF5NgX1oXd5RR0" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="FuTTwqCLCdqN6oRMWFekrf" Comment="" Bounds="437,319,87,15" ShowValueBox="true" isIOBox="true" Value="Texture2D">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.dll">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.dll">
                           <Choice Kind="TypeFlag" Name="TextureDimension" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Node Bounds="415,343,25,19" Id="NrkyCrWovyxNyZpUuEbMeL">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDimension" LastSymbolSource="Stride.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDimension" LastDependency="Stride.dll">
                           <CategoryReference Kind="AssemblyCategory" Name="TextureDimension" />
                           <Choice Kind="OperationCallFlag" Name="=" />
                         </p:NodeReference>
@@ -1541,12 +1541,12 @@
                         <Pin Id="Lh17VM87AuDLHMrsqxekie" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="EkFH07zqFqNPX0U6XkjwSS" Comment="" Bounds="511,261,20,15" ShowValueBox="true" isIOBox="true" Value="1">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="Integer32" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Node Bounds="415,371,79,19" Id="DcthWlhDpNpOoCG7zED2zD">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                           <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
@@ -1556,7 +1556,7 @@
                         <Pin Id="IPIEkGfbyZaOR61EHriw3j" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="109,469,620,620" Id="SXvEODGGF9ZLAbMmYPwUft">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
@@ -1572,7 +1572,7 @@
                           <Patch Id="SepAOIhO1WDNvvEaOuL5AM" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="PeHBNNbZ33RMyq1i7DZaL4" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="224,577,397,145" Id="Okvla0domv8QCEnN7GRbNa">
-                            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ApplicationStatefulRegion" Name="If" />
                               <FullNameCategoryReference ID="Primitive" />
@@ -1588,7 +1588,7 @@
                               <Patch Id="OIkhnyvo09CMLm3m5QCahW" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="B2HGMHXA2o3MMNtcUYCj9n" Name="Then" ManuallySortedPins="true" />
                               <Node Bounds="466,672,36,19" Id="C7OqFURMOjkMiJqHn9lqc9">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastSymbolSource="Stride.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastDependency="Stride.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <CategoryReference Kind="AssemblyCategory" Name="Stride" />
                                   <CategoryReference Kind="AssemblyCategory" Name="Graphics" />
@@ -1599,14 +1599,14 @@
                                 <Pin Id="Qs4PB19GAjVQEaSfdZKgUY" Name="Result" Kind="OutputPin" />
                               </Node>
                               <Node Bounds="342,613,104,26" Id="CiJWI7uGLofMWvtSf1vbS2">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" />
                                   <Choice Kind="OperationCallFlag" Name="SetArraySize" />
                                 </p:NodeReference>
                                 <Pin Id="Cn8S4AdOoeGOcinZAhMu23" Name="Input" Kind="StateInputPin" />
                                 <Pin Id="Iuqc9aJgspgOD0SU08zKv7" Name="Value" Kind="InputPin" DefaultValue="0">
-                                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                     <Choice Kind="TypeFlag" Name="Integer32" />
                                   </p:TypeAnnotation>
                                 </Pin>
@@ -1615,7 +1615,7 @@
                             </Patch>
                           </Node>
                           <Node Bounds="164,538,65,19" Id="A7dOZxCXWFxNR7HUvlDCBn">
-                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                             </p:NodeReference>
@@ -1624,7 +1624,7 @@
                             <Pin Id="FyWW8REIAm5NsqcJNHlG8R" Name="Not Assigned" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="224,812,493,227" Id="KWwjrYs3dzvLkokY6oSeiZ">
-                            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <CategoryReference Kind="Category" Name="Primitive" />
                               <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
@@ -1645,7 +1645,7 @@
                               <Patch Id="T34Gl3PepmROzLJroUtjvA" Name="Dispose" ManuallySortedPins="true" />
                               <ControlPoint Id="DDB3uiUaItLP0nW04CCEGX" Bounds="544,830" />
                               <Node Bounds="236,905,80,26" Id="ADPVEfVBYITMCDgQ8wIhnk">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastSymbolSource="Stride.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastDependency="Stride.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="GetPixelBuffer" />
                                 </p:NodeReference>
@@ -1656,7 +1656,7 @@
                                 <Pin Id="JAY4U4r20nFMJB2SwJ8Zdh" Name="Result" Kind="OutputPin" />
                               </Node>
                               <Node Bounds="465,905,81,26" Id="LUlRaoaVEyqPAEkFSe0fSI">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastSymbolSource="Stride.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastDependency="Stride.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <CategoryReference Kind="AssemblyCategory" Name="Image" />
                                   <Choice Kind="OperationCallFlag" Name="GetPixelBuffer" />
@@ -1668,7 +1668,7 @@
                                 <Pin Id="IiGt7ZPQJSxM5276cCVZsG" Name="Result" Kind="OutputPin" />
                               </Node>
                               <Node Bounds="311,975,55,26" Id="UvL7sQsA0uaN4MY2EiOzaB">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastSymbolSource="Stride.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.PixelBuffer" LastDependency="Stride.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <CategoryReference Kind="AssemblyCategory" Name="PixelBuffer" />
                                   <Choice Kind="OperationCallFlag" Name="CopyTo" />
@@ -1680,7 +1680,7 @@
                             </Patch>
                           </Node>
                           <Node Bounds="342,742,79,26" Id="O52TStbGaQnN5JnsV7UJoR">
-                            <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastSymbolSource="Stride.dll">
+                            <p:NodeReference LastCategoryFullName="Stride.Graphics.ImageDescription" LastDependency="Stride.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="MipLevels" />
                               <CategoryReference Kind="AssemblyCategory" Name="ImageDescription" NeedsToBeDirectParent="true" />
@@ -1693,7 +1693,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="233,150,60,19" Id="KYmlNj4cJp0O45AeCgeUvL">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Image" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="Category" Name="Stride" />
                           <CategoryReference Kind="Category" Name="Graphics" />
@@ -1702,7 +1702,7 @@
                         </p:NodeReference>
                         <Pin Id="UHp25vljzDoNRcGg9jkEZO" Name="File Path" Kind="InputPin" />
                         <Pin Id="Lm7JqrUxlzHQcsEQ64o9P5" Name="Load As SRGB" Kind="InputPin" DefaultValue="False">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Boolean" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -1710,7 +1710,7 @@
                       </Node>
                       <ControlPoint Id="T6U5XXRSjkcOoasv2egdaW" Bounds="684,381" />
                       <Node Bounds="236,1108,53,19" Id="RJsYlScYsKxOyV0Hmv9Vz9">
-                        <p:NodeReference LastCategoryFullName="Stride.Core.Utilities" LastSymbolSource="Stride.Core.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Core.Utilities" LastDependency="Stride.Core.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="AssemblyCategory" Name="Stride" />
                           <CategoryReference Kind="AssemblyCategory" Name="Utilities" />
@@ -1721,7 +1721,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="434,1185,65,19" Id="ShQUIeAolfuNN0npdivw5B">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                     </p:NodeReference>
@@ -1730,7 +1730,7 @@
                     <Pin Id="CcX2KgBXhYcL8dBg9T6VLm" Name="Not Assigned" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="434,1217,278,136" Id="PPsfmBiGtHKQJfP7QNeTs8">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <FullNameCategoryReference ID="Primitive" />
@@ -1744,7 +1744,7 @@
                       <Patch Id="Ty6t4ADHMjlNeCGTe5F0W0" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="L4krsnJLYx5NiJw8IfkbSG" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="446,1302,65,19" Id="IYt50bK6a9wM9myCHFoRPv">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="New" />
                           <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -1754,14 +1754,14 @@
                         <Pin Id="T2PRk8UjfXNQG3Nu0wZ0tv" Name="Image" Kind="InputPin" />
                         <Pin Id="J7cWnxVJM3cLA7vNOqpoT9" Name="Texture Flags" Kind="InputPin" />
                         <Pin Id="V0wq5EWEmbmODvFmtBPzTV" Name="Usage" Kind="InputPin" DefaultValue="Immutable">
-                          <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.Graphics.dll">
+                          <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                             <Choice Kind="TypeFlag" Name="GraphicsResourceUsage" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="PQ1BCszP9MuLv7jW700N04" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="446,1242,86,19" Id="NeDwZTs3Z5xOwpDPh8efkU">
-                        <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="GraphicsDevice" />
                           <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -1771,19 +1771,19 @@
                         <Pin Id="Q7DrPHmyM5hLt2vBDkwbbD" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Pad Id="EtdJzJn0cDxPMGjUIIrY7x" Comment="Texture Flags" Bounds="488,1272,128,15" ShowValueBox="true" isIOBox="true" Value="ShaderResource">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.Graphics.dll">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="TypeFlag" Name="TextureFlags" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Pad Id="CKMgUrx65jIM3WtI1Z5v3z" Comment="Usage" Bounds="508,1293,77,15" ShowValueBox="true" isIOBox="true" Value="Immutable">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.Graphics.dll">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="TypeFlag" Name="GraphicsResourceUsage" />
                         </p:TypeAnnotation>
                       </Pad>
                     </Patch>
                   </Node>
                   <Node Bounds="584,1363,53,19" Id="JlJ0gSaLZs0OOaKqlMCU3O">
-                    <p:NodeReference LastCategoryFullName="Stride.Core.Utilities" LastSymbolSource="Stride.Core.dll">
+                    <p:NodeReference LastCategoryFullName="Stride.Core.Utilities" LastDependency="Stride.Core.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Stride" />
                       <CategoryReference Kind="AssemblyCategory" Name="Utilities" />
@@ -1893,8 +1893,8 @@
               </p:NodeReference>
               <Patch Id="JDxlXWKUn6dMp7sKzSoKEp">
                 <Canvas Id="Ipi3TjgXMxNPkgaFH4QYsj" CanvasType="Group">
-                  <Node Bounds="96,138,195,112" Id="KGO7sEV9QK4N4GOkStLO5j">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                  <Node Bounds="96,138,195,113" Id="KGO7sEV9QK4N4GOkStLO5j">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -1908,7 +1908,7 @@
                       <Patch Id="Ig9Dqj8F0A9LhcnJlPuhLs" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="IEvKb24gFwZLMmOCVNmrZg" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="110,194,94,26" Id="Ms7OPmTbyM7PMZc8I8edYJ">
-                        <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="ClassType" Name="GenericComputeNode" />
                           <Choice Kind="OperationCallFlag" Name="ByName" />
@@ -1919,7 +1919,7 @@
                         <Pin Id="H3LdLHsgF6OQL0NZgD4d5m" Name="Composition" Kind="InputPin" />
                       </Node>
                       <Pad Id="PAnc1g3kaZ9L2QbI7RxCqb" Comment="" Bounds="112,166,148,15" ShowValueBox="true" isIOBox="true" Value="SampleTextureArrayVector4">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -1928,7 +1928,7 @@
                   <ControlPoint Id="SCe4bDuW4gXNUlLKA16AQV" Bounds="112,281" />
                   <ControlPoint Id="HFbWAAJnObtNqdw2XdjfnI" Bounds="612,107" />
                   <Node Bounds="301,264,91,19" Id="CeJmp0GdozSPLTcgIB9ZY6">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="InputValueSetter" />
                     </p:NodeReference>
@@ -1937,12 +1937,12 @@
                     <Pin Id="NDPu3WaG9gcQF4FUW1M4dR" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="DJP1o3LOXc9NedHOTKY6YV" Comment="" Bounds="303,211,91,18" ShowValueBox="true" isIOBox="true" Value="ArrayTextureSize">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="517,261,96,19" Id="RjhLlbS2PubLV8ba5VRSHf">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="InputObjectSetter" />
                     </p:NodeReference>
@@ -1951,12 +1951,12 @@
                     <Pin Id="JcFoFPEZGaLMyZtwDcM8hR" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="RKLOkfvRhuaNsYIAM7Fxjr" Comment="" Bounds="519,226,74,15" ShowValueBox="true" isIOBox="true" Value="ArrayTexture">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="200,335,208,19" Id="Ll2vw7MvwliMPGwE2bjwQ5">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="InputParameterManager" />
                     </p:NodeReference>
@@ -1965,19 +1965,19 @@
                     <Pin Id="KUWuEnymnOyLFDm4L3mG9y" Name="Input Setter 2" Kind="InputPin" />
                   </Node>
                   <Node Bounds="96,101,54,19" Id="Qg8jm3vO245PlFALwcHZUj">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="OnOpen" />
                     </p:NodeReference>
                     <Pin Id="DMhlwkq1cgcPbE5V1QwH85" Name="Simulate" Kind="InputPin" DefaultValue="False">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Boolean" />
                       </p:TypeAnnotation>
                     </Pin>
                     <Pin Id="P37Nc95onSYOYUSYzhDVrx" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="413,202,74,19" Id="IMV07Cml90DMk6R3fL7iKm">
-                    <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetArraySize" />
                     </p:NodeReference>
@@ -1985,7 +1985,7 @@
                     <Pin Id="DGrz20BprJpMVXtNDwQa9b" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="387,240,58,19" Id="IR45XS0mcX2O2tLLq3NI0Q">
-                    <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToUInt32" />
                     </p:NodeReference>
@@ -2016,12 +2016,12 @@
                 <Patch Id="O4w3IxDvP1cM2huAfiABwn" Name="Create" />
                 <Patch Id="Uety9qupw1aMdEpDeoWRAN" Name="Update">
                   <Pin Id="R7cwpa7soqvNHn0NBO4Mzz" Name="Texture Array" Kind="InputPin" Bounds="1038,589">
-                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.vl">
                       <Choice Kind="TypeFlag" Name="Texture" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="ArTxQzTG9ZgLUaho6Y9Ngk" Name="Output" Kind="OutputPin" Bounds="293,471">
-                    <p:TypeAnnotation LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.vl">
                       <Choice Kind="TypeFlag" Name="GPU" />
                       <p:TypeArguments>
                         <TypeReference>
@@ -2039,13 +2039,13 @@
 
 -->
             <Node Name="RenderWithSimpleDrawShader" Bounds="86,425" Id="P9SoMSKlveOOIMqE1dY09g">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="KsztQwaa0EtLZLfMSuX6sI">
                 <Canvas Id="SMXx88tA1XKNxwPSyAysJ1" CanvasType="Group">
                   <Node Bounds="102,367,305,19" Id="LlpKgw4B0EJQB6EICoKo0K">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastSymbolSource="vl)">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="vl">
                       <Choice Kind="ProcessNode" Name="ArrayTextureInstancedShader" />
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     </p:NodeReference>
@@ -2058,7 +2058,7 @@
                     <Pin Id="OZjl59BSb2oPqplsjg2vaW" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="102,442,165,19" Id="BiTNpZjJDoHO836l6II51I">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
                     </p:NodeReference>
@@ -2074,7 +2074,7 @@
                     <Pin Id="TIzToGMNUw5MzVARCFZmwc" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Node Bounds="182,405,145,19" Id="VYtSUNTcidFL0X4xLosQ0p">
-                    <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                    <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.Rendering.Nodes">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessNode" Name="PlaneMesh" />
                     </p:NodeReference>
@@ -2089,7 +2089,7 @@
                     <Pin Id="TZxkmOvZeUSQMs5Hyd9MJI" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="82,479,165,19" Id="Et7tdmiQAGyO7R2i4Q806q">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="RenderEntity" />
                     </p:NodeReference>
@@ -2105,7 +2105,7 @@
                     <Pin Id="M6r4tdVQ6MLO4CtcAFDo03" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="102,203,105,19" Id="Iui2qaumwCWPVWMB3nt3iz">
-                    <p:NodeReference LastCategoryFullName="Stride.Buffers" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
                     </p:NodeReference>
@@ -2120,7 +2120,7 @@
                     <Pin Id="LdOP7s1UX3qNhGtvRkcXEc" Name="Has Changed" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="282,332,58,19" Id="BDtLa3XZImxLGrNh68aczt">
-                    <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToUInt32" />
                     </p:NodeReference>
@@ -2128,7 +2128,7 @@
                     <Pin Id="HTvqX6g3OJcMaYYreoVOaK" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="202,164,57,19" Id="C1heZojedmkN8kRv6GEJsf">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="Changed" />
                     </p:NodeReference>
@@ -2139,7 +2139,7 @@
                   <ControlPoint Id="MI3MXu28TrVOAEcSxlmqCs" Bounds="224,276" />
                   <ControlPoint Id="QDHFX7KKOkiOXGsoRXETsV" Bounds="84,517" />
                   <Node Bounds="202,232,44,26" Id="C7GQElgr5u7Mgg6s9QPYfE">
-                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Count" />
                       <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -2149,7 +2149,7 @@
                   </Node>
                   <ControlPoint Id="Fo0mPpYedn3QdsGNlg0i4z" Bounds="103,100" />
                   <Node Bounds="282,296,74,19" Id="MAmdIxp4nzfPLdh8TJQ3e0">
-                    <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetArraySize" />
                     </p:NodeReference>
@@ -2157,7 +2157,7 @@
                     <Pin Id="ScatqTo2AcMO5OglH9F3UP" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="342,333,76,19" Id="OzEMV6sErxaOAmv4wECTfT">
-                    <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="UniformScale" />
                       <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -2169,7 +2169,7 @@
                     <Pin Id="HMGBsaujHyHMso2mLcbrXr" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Pad Id="MhdgIIUiDdNNlEa7wTVK3X" Comment="Scaling" Bounds="415,302,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2200,7 +2200,7 @@
                 <Patch Id="SaHpQIY1SfsOYsaOAGqy2B" Name="Create" />
                 <Patch Id="FsZsosQ9FvzP9sWyyJElJm" Name="Update">
                   <Pin Id="G1KJmYL3dULOvBA1GgRCbM" Name="Transformations" Kind="InputPin" Bounds="182,87">
-                    <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Spread" />
                       <p:TypeArguments>
                         <TypeReference>
@@ -2220,13 +2220,13 @@
 
 -->
             <Node Name="RenderWithMaterialExtension" Bounds="89,471" Id="FkhG4xOPT4iLTlfE8XKwsy">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="JGhr6F5LXqkMpECbtA9j7B">
                 <Canvas Id="TGFmWyTctQmQSyHN92NiOb" CanvasType="Group">
                   <Node Bounds="805,309,139,19" Id="J8HFfIYxl3tMMbjx8v2vIX">
-                    <p:NodeReference LastCategoryFullName="Stride.Textures.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="Sample (Vector4)" />
                     </p:NodeReference>
@@ -2234,7 +2234,7 @@
                     <Pin Id="HNgi9l9VhpKPntYYtJsp7c" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="546,642,165,19" Id="Hz14GkPtsplOASsg3K5ZUL">
-                    <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="Sphere" />
                     </p:NodeReference>
@@ -2250,7 +2250,7 @@
                     <Pin Id="B7Z1sdvg7KaNYCEiTPWTYQ" Name="Entity" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="805,435,65,19" Id="GRogl0qEnagMperdI89kIA">
-                    <p:NodeReference LastCategoryFullName="Stride.Materials.ShadingAttributes" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                    <p:NodeReference LastCategoryFullName="Stride.Materials.ShadingAttributes" LastDependency="VL.Stride.Rendering.Nodes">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessNode" Name="Emissive" />
                     </p:NodeReference>
@@ -2261,7 +2261,7 @@
                     <Pin Id="EjoGgo25gNNPPfJBMvUHQT" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="883,501,147,19" Id="TKJy4FurLZgMjSzKbWqQDc">
-                    <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="InstancingSpreadComponent" />
                     </p:NodeReference>
@@ -2272,7 +2272,7 @@
                     <Pin Id="RYkT5y87wdZLt67ZQjMXDC" Name="Component" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="546,583,76,19" Id="NL0ATo0Z6E3MuEe78UNIoj">
-                    <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="UniformScale" />
                       <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -2284,7 +2284,7 @@
                     <Pin Id="FCaArb1v3uRNiVccZzATAu" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Pad Id="UzKS6NFrkLzQCb8ZazQPbs" Comment="" Bounds="827,364,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                   </Pad>
@@ -2292,17 +2292,17 @@
                   <ControlPoint Id="UeJ3BcHapwlNhl9SAPEzQt" Bounds="885,454" />
                   <ControlPoint Id="UI6tstHgQoJQaVQyqVRYgn" Bounds="807,278" />
                   <Pad Id="GCdX94eFNjhLhdKUX02eUh" Comment="Scaling" Bounds="619,562,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Pad Id="NUdhEuefiZINANZwJaiJGb" Comment="" Bounds="980,484,84,15" ShowValueBox="true" isIOBox="true" Value="PreMultiply">
-                    <p:TypeAnnotation LastCategoryFullName="Stride.Engine" LastSymbolSource="Stride.Engine.dll">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.Engine" LastDependency="Stride.Engine.dll">
                       <Choice Kind="TypeFlag" Name="ModelTransformUsage" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="605,500,265,19" Id="T5tuRIuuEvhOYAoOnwIbmE">
-                    <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Materials" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="PBRMaterial (Specular)" />
                     </p:NodeReference>
@@ -2323,7 +2323,7 @@
                     <Pin Id="BusKBG7YoJNP0pOuMvPXs0" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="883,532,65,19" Id="Dl8Eh2qH97gLfJjWL4nciE">
-                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FromValue" />
                       <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -2332,7 +2332,7 @@
                     <Pin Id="EpQofe88C7cLxY7iR99Qh2" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="825,391,25,19" Id="DEdywQB99hrMcrFKgb4u6F">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="In" />
                       <CategoryReference Kind="Category" Name="ShaderFX" NeedsToBeDirectParent="true" />
@@ -2382,7 +2382,7 @@
               <Patch Id="PCY7JrOAt3AOXamFva7bRg">
                 <Canvas Id="Fz0NFBa0MWcLXa68ISzLKK" CanvasType="Group">
                   <Node Bounds="147,345,205,112" Id="NTFIvXezQsyQRcfD0vbgEg">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -2396,7 +2396,7 @@
                       <Patch Id="UBh2zaycYAoPD7oPBUzmYS" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="RiWFRV9ZR5RNmCJMb1VU19" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="161,401,94,26" Id="S9llNYHpKFIOWVuN7dkTlG">
-                        <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="ClassType" Name="GenericComputeNode" />
                           <Choice Kind="OperationCallFlag" Name="ByName" />
@@ -2407,7 +2407,7 @@
                         <Pin Id="FIiQN1t3QWDOmGOYQOKCjg" Name="Composition" Kind="InputPin" />
                       </Node>
                       <Pad Id="Cd5hBIT91acNHdncgCQqDz" Comment="" Bounds="163,373,193,14" ShowValueBox="true" isIOBox="true" Value="SampleTextureArrayVector4WithIndex">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                       </Pad>
@@ -2416,7 +2416,7 @@
                   <ControlPoint Id="BV4NXNQs9peOxm9O0z3fbJ" Bounds="163,497" />
                   <ControlPoint Id="MopoZI6Va0NQd4DmXWnXGY" Bounds="790,112" />
                   <Node Bounds="399,335,91,19" Id="DtUJSZXaHG9Ng1AEiN9BCf">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="InputValueSetter" />
                     </p:NodeReference>
@@ -2425,12 +2425,12 @@
                     <Pin Id="JjTVpmoTBuzPbAZGZWhjvZ" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="BjCnd8sIT2tLIC0cpPiT2K" Comment="" Bounds="401,303,91,18" ShowValueBox="true" isIOBox="true" Value="ArrayTextureSize">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="699,429,96,19" Id="IQA0esKD8cKMtWIE9ODqjm">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="InputObjectSetter" />
                     </p:NodeReference>
@@ -2439,12 +2439,12 @@
                     <Pin Id="LCY7rPQ4Y60Pq40MMOg1m8" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="MEPnK7pDg4nLy0wLTAYlzf" Comment="" Bounds="701,405,74,15" ShowValueBox="true" isIOBox="true" Value="ArrayTexture">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="249,488,605,19" Id="D9xyM2LJVV0MPPoAe664Or">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="InputParameterManager" />
                     </p:NodeReference>
@@ -2455,19 +2455,19 @@
                     <Pin Id="T3tPvTy7bC0OwdtBKPZCKE" Name="Input Setter 4" Kind="InputPin" />
                   </Node>
                   <Node Bounds="147,308,54,19" Id="TXKG4bZQvcYQIZGcgP6WSU">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="OnOpen" />
                     </p:NodeReference>
                     <Pin Id="RyrYyBUTlTZOSVNt0p73hb" Name="Simulate" Kind="InputPin" DefaultValue="False">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Boolean" />
                       </p:TypeAnnotation>
                     </Pin>
                     <Pin Id="CwLG9qUVWiVP7F3dmXXldC" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="523,248,74,19" Id="L1GAkgjKS2TLowndmbCcEz">
-                    <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetArraySize" />
                     </p:NodeReference>
@@ -2475,7 +2475,7 @@
                     <Pin Id="Eo3Y66dWgmwNGnSVI9WZwR" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="523,293,58,19" Id="UoKlncQzScILXkQI8FR3f0">
-                    <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToUInt32" />
                     </p:NodeReference>
@@ -2483,7 +2483,7 @@
                     <Pin Id="EpdjCdRnKUULUjr83bGNo7" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="849,429,96,19" Id="FiReS4oYdz3QTITsyDOqrE">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="InputObjectSetter" />
                     </p:NodeReference>
@@ -2492,12 +2492,12 @@
                     <Pin Id="Vg3zB8mcDaqL2FF3KrfYiY" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="E78hFfD4GP5Nmu6Kh3l3RX" Comment="" Bounds="851,405,74,15" ShowValueBox="true" isIOBox="true" Value="Indices">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="549,429,91,19" Id="FimvkgsYGTbNsAHG1D4lEa">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="InputValueSetter" />
                     </p:NodeReference>
@@ -2506,12 +2506,12 @@
                     <Pin Id="R0Y7JGnSuPKPdacaEEPaH1" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="C6F011lkchRP3ZXO2AorYo" Comment="" Bounds="551,405,91,18" ShowValueBox="true" isIOBox="true" Value="IndicesSize">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="635,366,58,19" Id="TPcaymifs4mOih9eGjXZj3">
-                    <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToUInt32" />
                     </p:NodeReference>
@@ -2520,7 +2520,7 @@
                   </Node>
                   <ControlPoint Id="OYJh1JQb0XiMOgeIgB8n8t" Bounds="941,110" />
                   <Node Bounds="632,249,106,80" Id="Soevqe2GoZvQS4Vf5DykRI">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <FullNameCategoryReference ID="Primitive" />
@@ -2532,7 +2532,7 @@
                       <Patch Id="SrdFBgtP4iVN15n9qN1JYG" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="MeKPjlaplf6LiFSspkBK3k" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="644,282,80,26" Id="Sw0WRE7veYBO5C1kjlNt7m">
-                        <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Buffer" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Buffer" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="ClassType" Name="Buffer" />
                           <Choice Kind="OperationCallFlag" Name="ElementCount" />
@@ -2544,7 +2544,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="632,215,65,19" Id="Hula4uYdjYWP63jbOV9vrF">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                     </p:NodeReference>
@@ -2589,13 +2589,13 @@
                 <Patch Id="FM4OU9SHuNgMrq6oqGmq6u" Name="Create" />
                 <Patch Id="LnExaxAqvlLLR5Xxp9XeYK" Name="Update">
                   <Pin Id="KcUjwAzYdHrMpV3hk0zLKW" Name="Texture Array" Kind="InputPin" Bounds="1038,589">
-                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.vl">
                       <Choice Kind="TypeFlag" Name="Texture" />
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="PPmCS2giHavMNK2wR6yJVf" Name="Indices Buffer" Kind="InputPin" Bounds="1125,310" />
                   <Pin Id="CkCxmeNEVxmLdNPNNK457D" Name="Output" Kind="OutputPin" Bounds="293,471">
-                    <p:TypeAnnotation LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.vl">
                       <Choice Kind="TypeFlag" Name="GPU" />
                       <p:TypeArguments>
                         <TypeReference>
@@ -2609,18 +2609,18 @@
             </Node>
             <!--
 
-    ************************ GetSlice ************************
+    ************************ GetItem ************************
 
 -->
-            <Node Name="GetSlice" Bounds="744,150" Id="LwmdrE2wPKBL1UFfzRx4Qk">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <Node Name="GetItem" Bounds="743,150" Id="LwmdrE2wPKBL1UFfzRx4Qk">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="DMQxob8X1mfMTWeMHn5mTa">
                 <Canvas Id="NolfFQEZZLJNOaWwidzUr8" CanvasType="Group">
                   <ControlPoint Id="Gzk1ylKir8iLt1bm5GN2Wd" Bounds="534,90" />
                   <Node Bounds="987,873,92,19" Id="NtpL5z4HCGiN1TiOUsPFtQ">
-                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="GraphicsContext" />
                       <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -2630,7 +2630,7 @@
                     <Pin Id="NiT8YCe4K62N6rjPeSR6oa" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="987,906,79,26" Id="PgGDpVxA6E1NIbK36M1qPt">
-                    <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsContext" LastSymbolSource="Stride.Graphics.dll">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsContext" LastDependency="Stride.Graphics.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="GraphicsContext" />
                       <Choice Kind="OperationCallFlag" Name="CommandList" />
@@ -2640,7 +2640,7 @@
                     <Pin Id="K1bRM4m9YtQMCYYVFsFoqH" Name="Command List" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="660,98,86,19" Id="J0lzgIqSFXVPezPuj1P1KY">
-                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="GraphicsDevice" />
                       <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -2651,7 +2651,7 @@
                   </Node>
                   <ControlPoint Id="KviyJAZ19ZWQcftlTGUUHK" Bounds="1504,608" />
                   <Node Bounds="296,148,476,452" Id="D58jzR1JbHFMrr2PocTWyM">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                       <FullNameCategoryReference ID="Primitive" />
                     </p:NodeReference>
@@ -2665,25 +2665,25 @@
                     <Patch Id="EDOIj5tMMxxOjczO7sFyDu" ManuallySortedPins="true">
                       <Patch Id="IM0UpU8NcoTLnyBY54qjgC" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="KR2HNGD0XWJOUdneHFmAQc" Name="Then" ManuallySortedPins="true" />
-                      <Node Bounds="319,221,441,344" Id="NTUYRDAGMq3QDZYQbDfLrS">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+                      <Node Bounds="319,221,441,345" Id="NTUYRDAGMq3QDZYQbDfLrS">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <FullNameCategoryReference ID="Primitive" />
                         </p:NodeReference>
                         <Pin Id="MDu2MqNKK5UO15MU3SDI1Z" Name="Condition" Kind="InputPin" />
                         <ControlPoint Id="Nz0WW5eQEWlQdw3tkZqxJQ" Bounds="535,560" Name="textureArray" Alignment="Bottom" />
-                        <ControlPoint Id="HKX3uUz95S9NV9QxbTCOGt" Bounds="534,228" Name="textureArray" Alignment="Top" />
+                        <ControlPoint Id="HKX3uUz95S9NV9QxbTCOGt" Bounds="534,227" Name="textureArray" Alignment="Top" />
                         <ControlPoint Id="COvYwHkfIPfMxGW8MsIV62" Bounds="640,560" Name="targetTex" Alignment="Bottom" />
-                        <ControlPoint Id="BSy3C3tV46MO0sGf7iVo8E" Bounds="690,228" Name="targetTex" Alignment="Top" />
+                        <ControlPoint Id="BSy3C3tV46MO0sGf7iVo8E" Bounds="690,227" Name="targetTex" Alignment="Top" />
                         <ControlPoint Id="G7NFdyjuaK1QUbdx446cGX" Bounds="429,560" Name="ArraySize" Alignment="Bottom" />
-                        <ControlPoint Id="Qu9Ex0PiWaKQQORLdVvd9x" Bounds="430,228" Name="ArraySize" Alignment="Top" />
+                        <ControlPoint Id="Qu9Ex0PiWaKQQORLdVvd9x" Bounds="430,227" Name="ArraySize" Alignment="Top" />
                         <ControlPoint Id="LhbCHtqen5NNNhJliVmk56" Bounds="333,560" Name="MipLevels" Alignment="Bottom" />
-                        <ControlPoint Id="HF8b4JkOaoBOD4E4MomUuV" Bounds="335,228" Name="MipLevels" Alignment="Top" />
+                        <ControlPoint Id="HF8b4JkOaoBOD4E4MomUuV" Bounds="335,227" Name="MipLevels" Alignment="Top" />
                         <Patch Id="VPqnbBNKp1vOg8rvD7YnKx" ManuallySortedPins="true">
                           <Patch Id="JeAGzPAjipRLJBJKPft8cD" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="QH8RdACxqRmOnXfHZY2wo9" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="532,244,111,26" Id="RL67y1DdMF6MSuE2Uo9Dh0">
-                            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                            <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Description" />
                               <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -2693,7 +2693,7 @@
                             <Pin Id="UTJ511xjkjrPOSAnoHbWi4" Name="Description" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="521,337,85,26" Id="NWqFhUg8D5LLc6Dd2zdobx">
-                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Dimension" />
                               <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -2702,12 +2702,12 @@
                             <Pin Id="PUNMQ0zhgEgOKRodJ4U0bd" Name="Dimension" Kind="OutputPin" />
                           </Node>
                           <Pad Id="FMxqS70m4yYPU3TUpxKR1a" Comment="" Bounds="543,375,87,15" ShowValueBox="true" isIOBox="true" Value="Texture2D">
-                            <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.dll">
+                            <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.dll">
                               <Choice Kind="TypeFlag" Name="TextureDimension" />
                             </p:TypeAnnotation>
                           </Pad>
                           <Node Bounds="521,412,25,19" Id="RHwwV9qFKc5MigPPdjTA4Y">
-                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDimension" LastSymbolSource="Stride.dll">
+                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDimension" LastDependency="Stride.dll">
                               <CategoryReference Kind="AssemblyCategory" Name="TextureDimension" />
                               <Choice Kind="OperationCallFlag" Name="=" />
                             </p:NodeReference>
@@ -2716,7 +2716,7 @@
                             <Pin Id="NUY0nYTbuSaL5x6Rj4LcEB" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="521,462,227,84" Id="Cl6iugWvHweMor5bhtzvgn">
-                            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ApplicationStatefulRegion" Name="If" />
                               <CategoryReference Kind="Category" Name="Primitive" />
@@ -2730,7 +2730,7 @@
                               <Patch Id="Qrb6kT3YnJyLaiDRi4wzyE" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="Ms82jh3ookhMJnPM58dYBK" Name="Then" ManuallySortedPins="true" />
                               <Node Bounds="638,500,49,19" Id="Dh0Lb72oiPWPTTvpZ5We4f">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="New2D" />
                                   <CategoryReference Kind="Category" Name="TextureArray" NeedsToBeDirectParent="true" />
@@ -2743,7 +2743,7 @@
                             </Patch>
                           </Node>
                           <Node Bounds="331,338,85,26" Id="FxA6S6CY6gFQN2jRrHjVpH">
-                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="MipLevels" />
                               <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -2752,7 +2752,7 @@
                             <Pin Id="JcMLr3RJ3BJMLqfu8jFCH3" Name="Mip Levels" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="428,337,85,26" Id="GcZCBmUE3sfQGEDxAnqLHl">
-                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="ArraySize" />
                               <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -2763,7 +2763,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="318,190,65,19" Id="LmUrrDapSofOg8xbA21zy9">
-                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                         </p:NodeReference>
@@ -2775,7 +2775,7 @@
                     </Patch>
                   </Node>
                   <Pad Id="FFVIfPLf0DsOlHoxoQTnzQ" Comment="Dispose Cached Outputs" Bounds="950,78,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
                       <FullNameCategoryReference ID="Primitive" />
                     </p:TypeAnnotation>
@@ -2784,7 +2784,7 @@
                     </p:ValueBoxSettings>
                   </Pad>
                   <Node Bounds="170,658,781,513" Id="BNz55aeWv5HP1O7ly53B5E">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -2801,7 +2801,7 @@
                       <Patch Id="LP4MD48iXnPNr8g9e7MfzB" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="LMaQnutkRaMPbasgPZl9ct" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="284,754,655,397" Id="P8cCYBFgfjnOSP61abElLO">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <FullNameCategoryReference ID="Primitive" />
                         </p:NodeReference>
@@ -2814,7 +2814,7 @@
                           <Patch Id="NTnhwzZ7ZhJLPKQPA7a9R7" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="TkrkbHcnEDUQUgT8fmpt0n" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="331,796,596,319" Id="UX6SkzKnewkP6TVUYeDSMz">
-                            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <CategoryReference Kind="Category" Name="Primitive" />
                               <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
@@ -2832,8 +2832,8 @@
                               </Patch>
                               <Patch Id="Hgg6DDLmtwYNw10kK5Hr1c" Name="Dispose" ManuallySortedPins="true" />
                               <ControlPoint Id="NBewHzjNTgVNgcghFGq233" Bounds="517,844" />
-                              <Node Bounds="354,962,561,96" Id="L5i3mqZ3jdkMiLLtO4Gt0H">
-                                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                              <Node Bounds="354,962,561,97" Id="L5i3mqZ3jdkMiLLtO4Gt0H">
+                                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                                   <FullNameCategoryReference ID="Primitive" />
@@ -2843,7 +2843,7 @@
                                   <Patch Id="L1q9Bwme9djOq2E3xE14n5" Name="Create" ManuallySortedPins="true" />
                                   <Patch Id="QijexCagw5eOaXPd6KMmQx" Name="Then" ManuallySortedPins="true" />
                                   <Node Bounds="387,1001,516,26" Id="H7wvA2PJJf0QAPh6dAHkZf">
-                                    <p:NodeReference LastCategoryFullName="Stride.Graphics.CommandList" LastSymbolSource="Stride.Graphics.dll">
+                                    <p:NodeReference LastCategoryFullName="Stride.Graphics.CommandList" LastDependency="Stride.Graphics.dll">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="OperationCallFlag" Name="CopyRegion" />
                                     </p:NodeReference>
@@ -2859,18 +2859,18 @@
                                     <Pin Id="SQUOJV8UbAWLHgnJzRE3w0" Name="Output" Kind="StateOutputPin" />
                                   </Node>
                                 </Patch>
-                                <ControlPoint Id="C4RaPaPCsJDOGvfvWrMj95" Bounds="369,969" Name="textureArray" Alignment="Top" />
+                                <ControlPoint Id="C4RaPaPCsJDOGvfvWrMj95" Bounds="369,968" Name="textureArray" Alignment="Top" />
                                 <ControlPoint Id="UXwFcY4LhVCPCdpxwWkTQH" Bounds="368,1053" Name="textureArray" Alignment="Bottom" />
-                                <ControlPoint Id="RAFME7BBLKKLyk6tQ6uIXN" Bounds="598,969" Name="targetTex" Alignment="Top" />
+                                <ControlPoint Id="RAFME7BBLKKLyk6tQ6uIXN" Bounds="598,968" Name="targetTex" Alignment="Top" />
                                 <ControlPoint Id="UZaVchImG76NRxg81mRoz7" Bounds="599,1053" Name="targetTex" Alignment="Bottom" />
                               </Node>
-                              <Pad Id="RnKk02EkQGwOsJASH8sQUt" Comment="" Bounds="356,932,25,28" ShowValueBox="true" isIOBox="true" Value="True">
-                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                              <Pad Id="RnKk02EkQGwOsJASH8sQUt" Comment="" Bounds="356,932,35,28" ShowValueBox="true" isIOBox="true" Value="True">
+                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                                   <Choice Kind="TypeFlag" Name="Boolean" />
                                 </p:TypeAnnotation>
                               </Pad>
                               <Node Bounds="367,888,153,26" Id="HhjeF4ccqWnMN2lpeFDk0s">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="GetSubResourceIndex" />
                                   <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -2882,7 +2882,7 @@
                                 <Pin Id="UQOwuLBIjgFLFjIYlWpltI" Name="Result" Kind="OutputPin" />
                               </Node>
                               <Node Bounds="596,885,115,26" Id="UPS4MOn2Wg1P9ZQ6j25ZnC">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="GetSubResourceIndex" />
                                   <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -2894,7 +2894,7 @@
                                 <Pin Id="Ex6xTgt5Ho6OD1J4RWZxUO" Name="Result" Kind="OutputPin" />
                               </Node>
                               <Node Bounds="788,846,51,26" Id="AdJxZvMV63YN5kzbqjNonV">
-                                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="ZMOD" />
                                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -2908,7 +2908,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="182,687,65,19" Id="BIb4QvW6pMQOiuzkDcrgWw">
-                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                         </p:NodeReference>
@@ -2917,7 +2917,7 @@
                         <Pin Id="SBsfM9U4ae3PIoKDpY1NQi" Name="Not Assigned" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="253,687,65,19" Id="JjH8pHa0oeAQMrLHQ2j797">
-                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                         </p:NodeReference>
@@ -2926,7 +2926,7 @@
                         <Pin Id="DpHzXTcl51QQdM78LABujn" Name="Not Assigned" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="182,717,76,19" Id="FsjITlrKFfuLb7ch9gQyuc">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                           <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
@@ -3041,12 +3041,12 @@
 
 -->
             <Node Name="New2D (Internal)" Bounds="637,320,457,223" Id="K80gcG6SODBQDjeQp29gmF">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
               <Patch Id="GoQMLPqnkarNSMhqefwp8x" ManuallySortedPins="true">
                 <Node Bounds="649,466,267,19" Id="SGYnX8kUoqjMH1yl2JYfnz">
-                  <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                  <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
                     <PinReference Kind="InputPin" Name="Mip Count" />
@@ -3064,7 +3064,7 @@
                   <Pin Id="LKGg1xgWbSQLLYQHYrx22b" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="682,386,345,19" Id="HPbV6bHbvy6NXUuta2Qehn">
-                  <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="VL.Addons.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="VL.Addons.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
                     <CategoryReference Kind="RecordType" Name="TextureDescription" NeedsToBeDirectParent="true">
@@ -3092,7 +3092,7 @@
                 <Pin Id="H6X6GhnwlaeMXp2eUYxrix" Name="Device" Kind="InputPin" Bounds="1150,1802" />
                 <Link Id="PhwdhXAa3FtLKvTCU7LBiU" Ids="H6X6GhnwlaeMXp2eUYxrix,DK8j8GlOTihQT6OT8pLEGA" IsHidden="true" />
                 <Node Bounds="682,422,38,19" Id="HCDh1hvSS1lM0xvVSPJicC">
-                  <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="Int2" />
                     <Choice Kind="OperationCallFlag" Name="Int2 (Split)" />
@@ -3105,7 +3105,7 @@
                 <Link Id="LmvuAJ9MoijQIorOG3UVNj" Ids="PYsZeemtpOLPa4aCDQvG9Y,T9K5hT5I1LgNzUtv58PQD7" />
                 <Link Id="PFshDFKCc4fPL20tE2jBac" Ids="JZx1R7n1nSnO7AxotDWEx1,VryfIXDroySPeuS72mxtRe" />
                 <Node Bounds="747,426,66,26" Id="JxdP97TuUHoPi8q81aepvt">
-                  <p:NodeReference LastCategoryFullName="Stride.Graphics.MipMapCount" LastSymbolSource="Stride.dll">
+                  <p:NodeReference LastCategoryFullName="Stride.Graphics.MipMapCount" LastDependency="Stride.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="MipMapCount" />
                     <Choice Kind="OperationCallFlag" Name="Create" />
@@ -3122,13 +3122,13 @@
                 <Pin Id="FFNihGWo8TZNkzxCAu3AJp" Name="Array Size" Kind="InputPin" Bounds="1346,1785" />
                 <Link Id="D9sAQd8f0iWONtee4MZfZt" Ids="FFNihGWo8TZNkzxCAu3AJp,Rnbk0W952NEOrJB2ej4PG6" IsHidden="true" />
                 <Pad Id="FFw9d5gtNgZQaJaN1a3iYG" Comment="Texture Flags" Bounds="815,428,128,15" ShowValueBox="true" isIOBox="true" Value="ShaderResource">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.Graphics.dll">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="TypeFlag" Name="TextureFlags" />
                   </p:TypeAnnotation>
                 </Pad>
                 <Link Id="NVVH369hiUmQMTUjorYno0" Ids="FFw9d5gtNgZQaJaN1a3iYG,RlES6M14OKWL1XupRcIyT8" />
                 <Pad Id="CC4frQCWlc4N50ygg6mWnz" Comment="Usage" Bounds="880,445,77,15" ShowValueBox="true" isIOBox="true" Value="Default">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.Graphics.dll">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="TypeFlag" Name="GraphicsResourceUsage" />
                   </p:TypeAnnotation>
                 </Pad>
@@ -3145,13 +3145,13 @@
 
 -->
             <Node Name="New2DArray (Internal)" Bounds="1121,317,482,262" Id="NEuwWYCUnTNMrPGk8utTp8">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
               <Patch Id="Evs9z8SAiszMGY9lrYd2dr">
                 <ControlPoint Id="R6G3RIyNxtqPCqnQrJaRzz" Bounds="1215,345" />
                 <Node Bounds="1246,401,38,19" Id="PugPiMlslmRNK4XVByGL0E">
-                  <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="Int2" />
                     <Choice Kind="OperationCallFlag" Name="Int2 (Split)" />
@@ -3161,7 +3161,7 @@
                   <Pin Id="Obpaa8OvzdSQFswxnCgnm4" Name="Y" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1311,385,66,26" Id="SgRui7PBcoYN5kBSOSme4K">
-                  <p:NodeReference LastCategoryFullName="Stride.Graphics.MipMapCount" LastSymbolSource="Stride.dll">
+                  <p:NodeReference LastCategoryFullName="Stride.Graphics.MipMapCount" LastDependency="Stride.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="MipMapCount" />
                     <Choice Kind="OperationCallFlag" Name="Create" />
@@ -3172,12 +3172,12 @@
                 </Node>
                 <ControlPoint Id="K1NGP5vnCMHPtyOfEkILHa" Bounds="1411,339" />
                 <Pad Id="U4MKGlAxaSpOoOw1XgErs6" Comment="Texture Flags" Bounds="1379,430,128,15" ShowValueBox="true" isIOBox="true" Value="ShaderResource">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.Graphics.dll">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="TypeFlag" Name="TextureFlags" />
                   </p:TypeAnnotation>
                 </Pad>
                 <Pad Id="QSQlSeLGLNxMNBmOREEOeQ" Comment="Usage" Bounds="1444,452,77,15" ShowValueBox="true" isIOBox="true" Value="Default">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.Graphics.dll">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="TypeFlag" Name="GraphicsResourceUsage" />
                   </p:TypeAnnotation>
                 </Pad>
@@ -3208,7 +3208,7 @@
                 <Pin Id="OlNXToBHPtGQRRwc7MVmM6" Name="Array Size" Kind="InputPin" Bounds="1346,1785" />
                 <Pin Id="L3w8hRBqjoyM7Inoex81Mx" Name="Output" Kind="OutputPin" Bounds="1069,2043" />
                 <Node Bounds="1201,452,291,72" Id="QUZACSbBhP2PkO6c7S3gVZ">
-                  <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="VL.CoreLib.Experimental.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Try (Stateless)" />
                   </p:NodeReference>
@@ -3220,7 +3220,7 @@
                     <Pin Id="J12kKUaJL9DOgdiNgHqIVC" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="AKuNI1cD3xKPn3MxNmLTmF" Bounds="1215,517" />
                     <Node Bounds="1213,475,267,19" Id="THMin58taMENnb1AR6T2V7">
-                      <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                      <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
                         <PinReference Kind="InputPin" Name="Mip Count" />
@@ -3250,13 +3250,13 @@
 
 -->
             <Node Name="New2DArray" Bounds="743,102" Id="KeNQRg0g0QVOrzgJHAsxrJ">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="VoSqcLm386GNQzSZzh63OR">
                 <Canvas Id="ALD5qDzO4dBLtjOCGZhrmS" CanvasType="Group">
                   <Node Bounds="210,216,300,86" Id="Q5D6hceSbb7M2AyR5JJKQB">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                       <FullNameCategoryReference ID="Primitive" />
                     </p:NodeReference>
@@ -3272,7 +3272,7 @@
                       <Patch Id="NXRSJ6ngBswQK8utSaPlYv" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="JJ0jfLRdrfZMmV5hLxBTxM" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="222,249,276,19" Id="BAIIUXyvdpiLxvBiqstC20">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture.TextureArray" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="New2DArray" />
                           <PinReference Kind="InputPin" Name="Array Size" />
@@ -3287,7 +3287,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="221,130,86,19" Id="PXGL4WWXuIyMjT0yQSX6ua">
-                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="GraphicsDevice" />
                       <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -3301,7 +3301,7 @@
                   <ControlPoint Id="Jz6QAM7o67sLQPWQ65ScIZ" Bounds="427,181" />
                   <ControlPoint Id="HplYEIcbWhCMvzNxf02g6d" Bounds="494,164" />
                   <Pad Id="I9nlDLh9l8dPEzEv3N6zz8" Comment="Dispose Cached Outputs" Bounds="507,188,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
                       <FullNameCategoryReference ID="Primitive" />
                     </p:TypeAnnotation>
@@ -3344,18 +3344,18 @@
             </Node>
             <!--
 
-    ************************ SetSlice ************************
+    ************************ SetItem ************************
 
 -->
-            <Node Name="SetSlice" Bounds="747,202" Id="NjSy5OVC4flMNMya8cbYYu">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <Node Name="SetItem" Bounds="743,202" Id="NjSy5OVC4flMNMya8cbYYu">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="ContainerDefinition" Name="Process" />
               </p:NodeReference>
               <Patch Id="FHZfvXzBUB3LLbLa9NqYCT">
                 <Canvas Id="TzsGaZQfF0zOzGVCSkeTGY" CanvasType="Group">
-                  <ControlPoint Id="HIp7VuQz2xxNdqvsb0tJ2w" Bounds="210,76" />
+                  <ControlPoint Id="HIp7VuQz2xxNdqvsb0tJ2w" Bounds="210,48" />
                   <Node Bounds="77,724,92,19" Id="K6YFmVeGv3sO1wJXQtO3m6">
-                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="GraphicsContext" />
                       <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -3365,7 +3365,7 @@
                     <Pin Id="UGxCTWgustaMqlcV3eeSZL" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="77,791,79,26" Id="LdqEAWd7XbmMVPW18fs5a3">
-                    <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsContext" LastSymbolSource="Stride.Graphics.dll">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsContext" LastDependency="Stride.Graphics.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="GraphicsContext" />
                       <Choice Kind="OperationCallFlag" Name="CommandList" />
@@ -3374,21 +3374,21 @@
                     <Pin Id="JwpiBetJiPbPrczoe7HoIq" Name="Output" Kind="StateOutputPin" />
                     <Pin Id="Vnjfs55ohZBLaE7l1zD3dc" Name="Command List" Kind="OutputPin" />
                   </Node>
-                  <ControlPoint Id="SWkG6WEMgZdO6cmslVMQ23" Bounds="602,51" />
-                  <ControlPoint Id="VD0P42nfdKxLoS5tWM7WOB" Bounds="546,71" />
+                  <ControlPoint Id="SWkG6WEMgZdO6cmslVMQ23" Bounds="602,48" />
+                  <ControlPoint Id="VD0P42nfdKxLoS5tWM7WOB" Bounds="546,48" />
                   <Node Bounds="210,286,688,734" Id="H56kwVfuRt9Owv85mtl3V1">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <FullNameCategoryReference ID="Primitive" />
                     </p:NodeReference>
                     <Pin Id="Jut8Tv3rnPMMH9xo9UGPaJ" Name="Condition" Kind="InputPin" DefaultValue="True" />
                     <ControlPoint Id="LRT3iEw0sG9NicmC55Nx5r" Bounds="546,292" Name="texArray" Alignment="Top" />
-                    <ControlPoint Id="DK2W2Ad0QJvNgqRu7ONgkZ" Bounds="547,1010" Name="texArray" Alignment="Bottom" />
+                    <ControlPoint Id="DK2W2Ad0QJvNgqRu7ONgkZ" Bounds="547,1014" Name="texArray" Alignment="Bottom" />
                     <Patch Id="KjV3qh8REltPsQmGVBnw9b" ManuallySortedPins="true">
                       <Patch Id="ILRYuR9FkLAPIkBGx88QKE" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="DqItGiZ1MiwNe4PffDwaqr" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="316,309,111,26" Id="H2r5LGTvWj4OjFK3B2d0cK">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Description" />
                           <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -3398,7 +3398,7 @@
                         <Pin Id="MWXFqfYfnc4QOWXutcP6vP" Name="Description" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="307,393,85,26" Id="BmjzM7IJ99uNslpaLqNUz1">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ArraySize" />
                           <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -3407,7 +3407,7 @@
                         <Pin Id="M4ht6n7s8o2P50NTEUpSgC" Name="Array Size" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="233,429,85,26" Id="Cgzx80pbFvhLbLKM99DtKv">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Dimension" />
                           <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -3416,25 +3416,25 @@
                         <Pin Id="EXEqnpFpQSEMPlo0aXPU1t" Name="Dimension" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="307,504,25,19" Id="TGhC24uCrFOPG6Sl47MWns">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="=" />
                         </p:NodeReference>
                         <Pin Id="DyleAcAajxuPzRYeOpoz8k" Name="Input" Kind="InputPin" />
                         <Pin Id="MZ3UExhfPQxPbX3HlCKgAa" Name="Input 2" Kind="InputPin" DefaultValue="1">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Integer32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="ObgNhkk4AnVPhwSUDwhQqr" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="NPrKqX1a762PlLT8wiu1b3" Comment="" Bounds="255,467,87,15" ShowValueBox="true" isIOBox="true" Value="Texture2D">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.dll">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.dll">
                           <Choice Kind="TypeFlag" Name="TextureDimension" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Node Bounds="233,504,25,19" Id="HlipXDyOLvsOZf0NYMbNDn">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDimension" LastSymbolSource="Stride.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDimension" LastDependency="Stride.dll">
                           <CategoryReference Kind="AssemblyCategory" Name="TextureDimension" />
                           <Choice Kind="OperationCallFlag" Name="=" />
                         </p:NodeReference>
@@ -3443,12 +3443,12 @@
                         <Pin Id="Pw1COadH9fAM8oWXvWgW16" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="QyV087b5PSnODHBzvteJjw" Comment="" Bounds="329,486,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="Integer32" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Node Bounds="233,534,79,19" Id="VL0pYGrk66JPYttYUz9Gsc">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                           <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
@@ -3458,7 +3458,7 @@
                         <Pin Id="BuE6DTLh4BbPFrFQ3nzmIa" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="233,586,653,414" Id="DvO420dNUjONTzwFAti4f4">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
@@ -3468,7 +3468,7 @@
                           <Patch Id="P3Gewnt6rWiOfUiFRiRJW0" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="VdT60bvZitKNRev92otmzU" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="280,680,594,298" Id="PA9kiGKI6ujQaQxDw9M4Dp">
-                            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <CategoryReference Kind="Category" Name="Primitive" />
                               <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
@@ -3483,7 +3483,7 @@
                               <Patch Id="KZSax7WhQTvMGD5tRbrN0K" Name="Dispose" ManuallySortedPins="true" />
                               <ControlPoint Id="BMeL00lQ2wHPmcWT7G3ZRQ" Bounds="750,700" />
                               <Node Bounds="303,846,559,102" Id="A6PtEkRu4wiM2jMg4c09wc">
-                                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                                   <FullNameCategoryReference ID="Primitive" />
@@ -3493,7 +3493,7 @@
                                   <Patch Id="TyN9iSGEt4ALz0KNuWeeXd" Name="Create" ManuallySortedPins="true" />
                                   <Patch Id="Qou0mm4PErDO1mIHZ8TivI" Name="Then" ManuallySortedPins="true" />
                                   <Node Bounds="334,889,516,26" Id="AmYEAySJ9kBLjfJjvgiEcU">
-                                    <p:NodeReference LastCategoryFullName="Stride.Graphics.CommandList" LastSymbolSource="Stride.Graphics.dll">
+                                    <p:NodeReference LastCategoryFullName="Stride.Graphics.CommandList" LastDependency="Stride.Graphics.dll">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="OperationCallFlag" Name="CopyRegion" />
                                     </p:NodeReference>
@@ -3515,12 +3515,12 @@
                                 <ControlPoint Id="VMXavRrOZxfNwRV7gVg4bN" Bounds="547,942" Name="texArray" Alignment="Bottom" />
                               </Node>
                               <Pad Id="FInZbU1HBrCOqHHRkXpY33" Comment="" Bounds="305,816,35,15" ShowValueBox="true" isIOBox="true" Value="True">
-                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                                   <Choice Kind="TypeFlag" Name="Boolean" />
                                 </p:TypeAnnotation>
                               </Pad>
                               <Node Bounds="315,766,153,26" Id="Fzhel0ZELgpLEfuo00QQw6">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="GetSubResourceIndex" />
                                   <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -3532,7 +3532,7 @@
                                 <Pin Id="MWGXYxqU6lHMQRjn1l7QwR" Name="Result" Kind="OutputPin" />
                               </Node>
                               <Node Bounds="544,763,115,26" Id="DXJMKbCdwVZMWdX83Uezo3">
-                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                                <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="GetSubResourceIndex" />
                                   <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -3550,7 +3550,7 @@
                             <ControlPoint Id="HTL7pl9zVbNOPWoGjkSVyy" Bounds="317,972" Name="InputTexture" Alignment="Bottom" />
                           </Node>
                           <Node Bounds="423,609,85,26" Id="CGFjd27ZThRLcnjI9AdWo2">
-                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                            <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="MipLevels" />
                               <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -3559,13 +3559,13 @@
                             <Pin Id="TKlxP4vMWEvOcKYBxleNDq" Name="Mip Levels" Kind="OutputPin" />
                           </Node>
                         </Patch>
-                        <ControlPoint Id="TR5M6SlBzD0M2kqS5evDGr" Bounds="545,593" Name="texArray" Alignment="Top" />
-                        <ControlPoint Id="Fyhx3cDXTPfOOHutv4ys7d" Bounds="547,990" Name="texArray" Alignment="Bottom" />
+                        <ControlPoint Id="TR5M6SlBzD0M2kqS5evDGr" Bounds="545,592" Name="texArray" Alignment="Top" />
+                        <ControlPoint Id="Fyhx3cDXTPfOOHutv4ys7d" Bounds="547,994" Name="texArray" Alignment="Bottom" />
                         <ControlPoint Id="BQVyq1Tgif1QdDaXCHN3gC" Bounds="317,592" Name="InputTexture" Alignment="Top" />
                         <ControlPoint Id="SGGifcgnNQpL1as1MapbgQ" Bounds="317,994" Name="InputTexture" Alignment="Bottom" />
                       </Node>
                       <Node Bounds="544,387,112,26" Id="U4iws7SnW7bMtLBrDGiPTe">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Description" />
                           <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
@@ -3575,7 +3575,7 @@
                         <Pin Id="Ms4AXbxUTZlLd2FR1TdWQb" Name="Description" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="651,436,85,26" Id="AWHDssbETisPB1W7URkV91">
-                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastSymbolSource="Stride.Graphics.dll">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureDescription" LastDependency="Stride.Graphics.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ArraySize" />
                           <CategoryReference Kind="AssemblyCategory" Name="TextureDescription" NeedsToBeDirectParent="true" />
@@ -3584,7 +3584,7 @@
                         <Pin Id="OJX9lk8GXMwMwAL1myeOK1" Name="Array Size" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="600,530,56,19" Id="ESaxHr9cNFVO90Xb9bthAg">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ZMOD" />
                         </p:NodeReference>
@@ -3595,7 +3595,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="210,202,65,19" Id="T1FML3LRd9HPetAzmmiB8A">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                     </p:NodeReference>
@@ -3603,26 +3603,8 @@
                     <Pin Id="G2e1mmNDuTBMyJjuVWc8R4" Name="Result" Kind="OutputPin" />
                     <Pin Id="UxHLPniejRINUGJunf6sGG" Name="Not Assigned" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="309,135,57,19" Id="TyqOCiPmnG3Nm60NmcR5mi">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="Changed" />
-                    </p:NodeReference>
-                    <Pin Id="EkGrTtDAs40MTXiBQfbljU" Name="Value" Kind="InputPin" />
-                    <Pin Id="P4M5FslPq3xLjf37p3Mf6z" Name="Result" Kind="OutputPin" />
-                    <Pin Id="Faz5jnkEqI1PPDpAzpeVdg" Name="Unchanged" Kind="OutputPin" />
-                  </Node>
-                  <Node Bounds="329,166,57,19" Id="DT3FAHdKL5yL1xyWh4dFkK">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="Changed" />
-                    </p:NodeReference>
-                    <Pin Id="EWvKpmNNTtuNJyxy1BskNd" Name="Value" Kind="InputPin" />
-                    <Pin Id="KjlZSGKGDncNzdIhI9cKPQ" Name="Result" Kind="OutputPin" />
-                    <Pin Id="Ark8z04XrrlNC0Dg2HJSjo" Name="Unchanged" Kind="OutputPin" />
-                  </Node>
                   <Node Bounds="289,106,57,19" Id="AtY0dXrQ1s1Lqte9tiTCFG">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="Changed" />
                     </p:NodeReference>
@@ -3631,7 +3613,7 @@
                     <Pin Id="IgGlNiUU9mBLEmANfW6AVV" Name="Unchanged" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="210,245,165,19" Id="CxtnJ0dgGQ8Pt174cTQNyv">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="AND" />
                       <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
@@ -3642,8 +3624,8 @@
                     <Pin Id="O3bd7moqK7hO0DaOH36pEg" Name="Input 3" Kind="InputPin" />
                   </Node>
                   <ControlPoint Id="QWjoU3fmp0zMXYax1FgPgU" Bounds="547,1072" />
-                  <Node Bounds="289,203,45,19" Id="JZl6vSfc3DkNYz3cpeXA6O">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <Node Bounds="289,203,65,19" Id="JZl6vSfc3DkNYz3cpeXA6O">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="OR" />
                       <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
@@ -3651,10 +3633,9 @@
                     <Pin Id="S3a1ZozqISxNtFUuxkBFg1" Name="Input" Kind="StateInputPin" />
                     <Pin Id="FbHWbFfYD1ZOEsDPzaMYIZ" Name="Input 2" Kind="InputPin" />
                     <Pin Id="VwdQDSNnMUuP7exINT6Xhy" Name="Output" Kind="StateOutputPin" />
-                    <Pin Id="DzXyflkLWYfMgLOcda84Xx" Name="Input 3" Kind="InputPin" />
                   </Node>
                   <Node Bounds="370,208,65,19" Id="BzG2jw0QYF0M1YVRMSKUlC">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                     </p:NodeReference>
@@ -3662,6 +3643,7 @@
                     <Pin Id="KWKhEdVIgHjOgVa6wV1D0X" Name="Result" Kind="OutputPin" />
                     <Pin Id="IIIULPqnbGiP4CBbkKnvrA" Name="Not Assigned" Kind="OutputPin" />
                   </Node>
+                  <ControlPoint Id="V3Ma7DVZkYCOP4FPoMVydT" Bounds="678,48" />
                 </Canvas>
                 <ProcessDefinition Id="PB2qfHqLVDMLqsw78h6Ayk">
                   <Fragment Id="RCxLHPiVPFBNeBlAuOu4xH" Patch="K2xV1EiYGz5MstbTfHA1I3" Enabled="true" />
@@ -3678,6 +3660,7 @@
                   <Pin Id="OPSQzc3TFM3NZ2tVrgJKwb" Name="Value" Kind="InputPin" />
                   <Pin Id="E8b3fcbr6Z2MR8z6cQ0a6v" Name="Index" Kind="InputPin" />
                   <Pin Id="UoqpiZQHzHbOMyr0saaq8u" Name="Output" Kind="OutputPin" Bounds="575,973" />
+                  <Pin Id="TsUuDiFVri3PwHlNFSqKFj" Name="Apply" Kind="InputPin" Bounds="678,47" />
                 </Patch>
                 <Link Id="AQaAYIBWOPPQNwW4gG4wYk" Ids="MWXFqfYfnc4QOWXutcP6vP,E87nldJP8p0PQUZgIzSQk1" />
                 <Link Id="VV8cN6oG0p2O2omtj7UFSv" Ids="M4ht6n7s8o2P50NTEUpSgC,DyleAcAajxuPzRYeOpoz8k" />
@@ -3702,8 +3685,6 @@
                 <Link Id="H3ZntQmiKQrPL28vB2vuQB" Ids="HIp7VuQz2xxNdqvsb0tJ2w,Nw6UXjjjYSVMGrlT4dBaWD" />
                 <Link Id="TuLY59hm8w1M7HGgFLLiCE" Ids="HIp7VuQz2xxNdqvsb0tJ2w,Cfri0izmESUPQUKwxWiPYX" />
                 <Link Id="NpeTQnQKqNxMQzfj3nqhJ0" Ids="MWXFqfYfnc4QOWXutcP6vP,FCRvWUFN9ktK9dV5Z3vgEn" />
-                <Link Id="COOy3reqINROr7srWqagv3" Ids="VD0P42nfdKxLoS5tWM7WOB,EkGrTtDAs40MTXiBQfbljU" />
-                <Link Id="FAHZynwgR1TLmj9pgO3PeX" Ids="SWkG6WEMgZdO6cmslVMQ23,EWvKpmNNTtuNJyxy1BskNd" />
                 <Link Id="QDs9WJ9KPjzPHdBhmDScxv" Ids="HIp7VuQz2xxNdqvsb0tJ2w,RYc2GeVOUusMNlYgkWhE2e" />
                 <Link Id="LhtBzU0TrNPNtm4CoQ2Ufc" Ids="G2e1mmNDuTBMyJjuVWc8R4,JwQxDLrLFtcPh4Ennwjyyr" />
                 <Link Id="Jiqjvtk84zMMXtuN4M8YEz" Ids="LRT3iEw0sG9NicmC55Nx5r,DK2W2Ad0QJvNgqRu7ONgkZ" IsFeedback="true" />
@@ -3721,8 +3702,6 @@
                 <Link Id="AJYkT9OKHWnLhytfNWaS8v" Ids="DK2W2Ad0QJvNgqRu7ONgkZ,QWjoU3fmp0zMXYax1FgPgU" />
                 <Link Id="BSvFhyfAILGMOshHvUnFtd" Ids="QWjoU3fmp0zMXYax1FgPgU,UoqpiZQHzHbOMyr0saaq8u" IsHidden="true" />
                 <Link Id="LRza0DINrouMdC7xgsLFv8" Ids="Aq747zgq8yrPp7oj4Z9I0w,S3a1ZozqISxNtFUuxkBFg1" />
-                <Link Id="RFDa5eTk6DdQdd5sLundYz" Ids="P4M5FslPq3xLjf37p3Mf6z,FbHWbFfYD1ZOEsDPzaMYIZ" />
-                <Link Id="DfD7UCI0OxQN2uRczalrSj" Ids="KjlZSGKGDncNzdIhI9cKPQ,DzXyflkLWYfMgLOcda84Xx" />
                 <Link Id="PTEFuMFXSxNMz4237VwVdn" Ids="VwdQDSNnMUuP7exINT6Xhy,RqhWJfbDD65OOp9g857E9i" />
                 <Link Id="HDGVag4ZEe3PTiM94FKflT" Ids="VD0P42nfdKxLoS5tWM7WOB,DYvn0ZIbBmGO7M721n9DqD" />
                 <Link Id="An0hNLCJVXiLueZ6vMWcbC" Ids="KWKhEdVIgHjOgVa6wV1D0X,O3bd7moqK7hO0DaOH36pEg" />
@@ -3741,6 +3720,8 @@
                 <Link Id="Bpnntx8dNXRMm0jSSJW3mK" Ids="HTL7pl9zVbNOPWoGjkSVyy,SGGifcgnNQpL1as1MapbgQ" />
                 <Link Id="IqsEIOyjoBlQYI1w37LDu1" Ids="RZncJgYTaPbMCnwS6NBAHc,Jut8Tv3rnPMMH9xo9UGPaJ" />
                 <Link Id="URwyFs5zQZ6MTKIHTmOIln" Ids="QpVsgVegzVnLuxwgEsumHE,Gaxmcw6Bkt9M1dqvp0IdFD" />
+                <Link Id="FIhJr1FapnSNPZC5j7zgeK" Ids="V3Ma7DVZkYCOP4FPoMVydT,FbHWbFfYD1ZOEsDPzaMYIZ" />
+                <Link Id="A5gBTfS9z5QOI4fF96JzZ3" Ids="TsUuDiFVri3PwHlNFSqKFj,V3Ma7DVZkYCOP4FPoMVydT" IsHidden="true" />
               </Patch>
             </Node>
           </Canvas>
@@ -3754,13 +3735,13 @@
 
 -->
           <Node Name="ColorPerInstance (Modulo)" Bounds="250,225" Id="UwVgASnNEB2LTCokfuf3mM" Summary="Upload a collection of colors to the GPU to control a float4 shader parameter per instance" Tags="gpu">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="ContainerDefinition" Name="Process" />
             </p:NodeReference>
             <Patch Id="JYSYVEtgUFyMaq6ES0OyRF" IsGeneric="true">
               <Canvas Id="Pfph67LQJuoNiYpAlgkY2P" CanvasType="Group">
                 <Node Bounds="100,160,145,19" Id="Vkz8hCsQZTELqlF2RDpew5">
-                  <p:NodeReference LastCategoryFullName="Stride.Buffers" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
                   </p:NodeReference>
@@ -3772,7 +3753,7 @@
                   <Pin Id="Gn5xXYJ34VyQcxOxpXYjKm" Name="Is Index Buffer" Kind="InputPin" />
                   <Pin Id="IB1zKvVLNIJLKtLJKnTFRt" Name="Recreate" Kind="InputPin" />
                   <Pin Id="SkB3NJXe7mFM3pcF860Lvp" Name="Apply" Kind="InputPin" DefaultValue="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -3780,7 +3761,7 @@
                   <Pin Id="L6CS0gqyScvLI0A36OOOUA" Name="Has Changed" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="100,277,79,19" Id="A4ltg0tAkcnMMNJ1T4eVtt">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Buffer" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Buffer" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="ShaderFX" />
                     <CategoryReference Kind="Category" Name="Buffer" />
@@ -3791,7 +3772,7 @@
                   <Pin Id="GCpYoDK2IjcLpLvwVQGyTf" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="100,219,52,19" Id="EAX0cSGrpQBNXpGz5bN6FE">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Buffer" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Buffer" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="ShaderFX" />
                     <CategoryReference Kind="Category" Name="Buffer" />
@@ -3801,7 +3782,7 @@
                   <Pin Id="S6cDxvHgUwCQCXaTfiNqVm" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="174,221,79,19" Id="RxF5dsuvFjMLvGVKW7PNrH">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Variables" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Variables" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="SV_InstanceId" />
                   </p:NodeReference>
@@ -3811,7 +3792,7 @@
                 <ControlPoint Id="Lp8ad8wKQGnPRKqwX39cxx" Bounds="102,450" />
                 <ControlPoint Id="KwLjVMaF5baN5g9b6GuhTD" Bounds="243,103" />
                 <Node Bounds="88,334,102,84" Id="G2bO7a6PauSLcy2i6ewdkE">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -3821,7 +3802,7 @@
                     <Patch Id="UDEEEDXSZq9PifDA1MKO6e" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="TuVh1ZybF3BPbHeez46VFm" Name="Then" ManuallySortedPins="true" />
                     <Node Bounds="100,366,78,19" Id="LeFVZjBYsgoMMJinU1eD5o">
-                      <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+                      <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="SRgbToLinear" />
                         <CategoryReference Kind="Category" Name="ShaderFX" NeedsToBeDirectParent="true" />
@@ -3835,7 +3816,7 @@
                 </Node>
                 <ControlPoint Id="J9pZPDdEZiRLUZ5T4Az79h" Bounds="436,101" />
                 <Node Bounds="434,132,194,162" Id="JZKK962vmkMLtXv7Kmg8Le">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <FullNameCategoryReference ID="Primitive" />
@@ -3847,7 +3828,7 @@
                     <Patch Id="CCJZbssuHdTOUOwR1k6PFW" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="TxhXH35PICzLDh8gtJ6pXy" Name="Then" ManuallySortedPins="true" />
                     <Node Bounds="446,157,86,19" Id="TMOgXlrvHocLWd0bdvU8GQ">
-                      <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                      <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="GraphicsDevice" />
                         <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -3857,7 +3838,7 @@
                       <Pin Id="EB7zTgbxSz9MbasVnqRhSo" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="446,193,71,26" Id="Mk80Irrb0IRNPYMDAib56R">
-                      <p:NodeReference LastCategoryFullName="Stride.API.Graphics.GraphicsDevice" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                      <p:NodeReference LastCategoryFullName="Stride.API.Graphics.GraphicsDevice" LastDependency="VL.Stride.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="ColorSpace" />
                         <CategoryReference Kind="ClassType" Name="GraphicsDevice" NeedsToBeDirectParent="true" />
@@ -3867,7 +3848,7 @@
                       <Pin Id="Eg0z56VV322LX2UlBWCBUO" Name="Color Space" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="512,250,25,19" Id="RcqG7YEOPrPPIGKZXfXxFW">
-                      <p:NodeReference LastCategoryFullName="Stride.Graphics.ColorSpace" LastSymbolSource="Stride.dll">
+                      <p:NodeReference LastCategoryFullName="Stride.Graphics.ColorSpace" LastDependency="Stride.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="=" />
                         <CategoryReference Kind="AssemblyCategory" Name="ColorSpace" NeedsToBeDirectParent="true" />
@@ -3877,14 +3858,14 @@
                       <Pin Id="STgYU8mMSKRLd43cCf24Lq" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Pad Id="KcaLfuEay4BPnrOZRC7B6J" Comment="" Bounds="534,216,63,15" ShowValueBox="true" isIOBox="true" Value="Linear">
-                      <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.dll">
+                      <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.dll">
                         <Choice Kind="TypeFlag" Name="ColorSpace" />
                       </p:TypeAnnotation>
                     </Pad>
                   </Patch>
                 </Node>
                 <Node Bounds="174,251,69,19" Id="VY07dFv3kzNMy0UhBHKQL3">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="vl)">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessNode" Name="ModuloGPU" />
                   </p:NodeReference>
@@ -3929,12 +3910,12 @@
                 <Pin Id="GTqce3J9VwONEwdhtIcVNg" Name="Apply" Kind="InputPin" Bounds="500,157" />
                 <Pin Id="IKVF0FtaMmHNEahLX8s2Dv" Name="Modulo" Kind="InputPin" Bounds="676,224" DefaultValue="2" />
                 <Pin Id="Mq5WOofhgN9LN2Fg2JG334" Name="To Device Color Space" Kind="InputPin" Bounds="850,210" DefaultValue="True" Visibility="Optional" Summary="If enabled and the pipline is set to linear color space (default), the shader converts the color to linear color space.">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="ANvX5L9V6HlQJZzyQb8ABQ" Name="Output" Kind="OutputPin" Bounds="400,462">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.vl">
                     <Choice Kind="TypeFlag" Name="GPU" />
                     <p:TypeArguments>
                       <TypeReference>
@@ -3952,13 +3933,13 @@
 
 -->
           <Node Name="ValuePerInstance (Modulo)" Bounds="250,173" Id="Rea9kFDhH6cQZ1PmWdgKDM" Summary="Upload a collection of values to the GPU to control a float shader parameter per instance" Tags="gpu">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="ContainerDefinition" Name="Process" />
             </p:NodeReference>
             <Patch Id="F2LUNG6YOXiPNr4BNSj6ZK" IsGeneric="true">
               <Canvas Id="T9tJkP3RD4oNtRWaomVKrz" CanvasType="Group">
                 <Node Bounds="97,126,145,19" Id="Bn8Ny2D6LKRNiPpE6lmBBW">
-                  <p:NodeReference LastCategoryFullName="Stride.Buffers" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
                   </p:NodeReference>
@@ -3970,7 +3951,7 @@
                   <Pin Id="BAxOC2bCCkjPvykhW9DGPH" Name="Is Index Buffer" Kind="InputPin" />
                   <Pin Id="NGNe4CB0lCHLNtMKMI1r93" Name="Recreate" Kind="InputPin" />
                   <Pin Id="AE1ZAPjjo9pPbtWZ2H9ql9" Name="Apply" Kind="InputPin" DefaultValue="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -3978,7 +3959,7 @@
                   <Pin Id="As7FLsg4m8tLVIrDghavKw" Name="Has Changed" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="97,266,79,19" Id="LSsyBcLGRXtOlrOCxLyFez">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Buffer" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Buffer" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="ShaderFX" />
                     <CategoryReference Kind="Category" Name="Buffer" />
@@ -3989,7 +3970,7 @@
                   <Pin Id="VOORfvDOGZDL9WvaaMY9Nv" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="97,178,67,19" Id="O2qQYez4BnoNtnEUxzYUMc">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Buffer" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Buffer" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="ShaderFX" />
                     <CategoryReference Kind="Category" Name="Buffer" />
@@ -3999,7 +3980,7 @@
                   <Pin Id="Kjh8hYCRJV0QYah47izuSB" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="171,178,79,19" Id="HWV5XEcicivNcTYibeJTiT">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Variables" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.Variables" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="SV_InstanceId" />
                   </p:NodeReference>
@@ -4009,7 +3990,7 @@
                 <ControlPoint Id="DnintNMoEKtNstJuO9F6Dc" Bounds="99,335" />
                 <ControlPoint Id="SJKALEdMddkMdN0GOiSB0n" Bounds="239,98" />
                 <Node Bounds="171,233,69,19" Id="Api3iZOoI4UQJulM7DqHjM">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="vl)">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessNode" Name="ModuloGPU" />
                   </p:NodeReference>
@@ -4041,7 +4022,7 @@
                 <Pin Id="TmRpxDQsJdaOphAi3FbYK9" Name="Apply" Kind="InputPin" Bounds="497,153" />
                 <Pin Id="SXCcgXD2RihN5Lz5o37iy6" Name="Modulo" Kind="InputPin" Bounds="676,224" DefaultValue="2" />
                 <Pin Id="K1a70exi1fyLaQAIz4Qqer" Name="Output" Kind="OutputPin" Bounds="400,462">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.vl">
                     <Choice Kind="TypeFlag" Name="GPU" />
                     <p:TypeArguments>
                       <TypeReference>
@@ -4062,13 +4043,13 @@
 
 -->
         <Node Name="WireBox" Bounds="116,128" Id="TgLzaHOJQVzQd1Rl3F76ow">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ClassDefinition" Name="Class" />
           </p:NodeReference>
           <Patch Id="Ob0JxKmfdHyNv0YgMDrzN9">
             <Canvas Id="NUxuL5eYcU5LdzdnLJdxpa" CanvasType="Group">
               <Node Bounds="303,408,288,19" Id="CC5Ef8PxRqwMS5axGkE43b">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.vl" LastDependency="VL.Stride.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
                 </p:NodeReference>
@@ -4084,7 +4065,7 @@
                 <Pin Id="MfAu4YkmCdvP2jKEfCPK77" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="282,503,165,19" Id="EIoDVg3mGp8PUOkK3OUiZE">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="RenderEntity" />
                 </p:NodeReference>
@@ -4100,7 +4081,7 @@
                 <Pin Id="I7OymXFOjE9PV3iWwBNAyT" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="444,339,145,19" Id="KmRSSCz9PWoPjqxBY0LL1l">
-                <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.Rendering.Nodes">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Meshes" />
                   <Choice Kind="ProcessNode" Name="BoxMesh" />
@@ -4115,7 +4096,7 @@
                 <Pin Id="LzsNLTefyPTLM9HJvpAVJC" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="303,341,133,19" Id="UCZzX3MfHxsOwGmbFgYsSF">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
                   <Choice Kind="ProcessNode" Name="SuppressDiagonalsShader" />
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 </p:NodeReference>
@@ -4171,7 +4152,7 @@
             <Patch Id="Qr4mpmk3iPZMhyu1VsTcmZ">
               <Canvas Id="DBMfMH8HMYZP5aPGsm1EVa" CanvasType="Group">
                 <Node Bounds="194,840,265,19" Id="NdxrZChWNdwM1lXKamjviw">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
                   </p:NodeReference>
@@ -4188,7 +4169,7 @@
                   <Pin Id="Vvl4rHCfrbNNkC3vPFJ5CO" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Pad Id="IHVYRL0LSFBNrubONXlgEC" Comment="Profiling Name" Bounds="369,822,132,15" ShowValueBox="true" isIOBox="true" Value="ColorQuadMeshDrawer">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pad>
@@ -4197,7 +4178,7 @@
                 <ControlPoint Id="HRIgaR1s0NDPwYRbveckDa" Bounds="599,127" />
                 <ControlPoint Id="GGvMRLAWMtHQINbbHhKUbS" Bounds="393,12" />
                 <Node Bounds="315,180,378,263" Id="OhYRbTjDaH0OLSmJyKvw4e">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -4209,7 +4190,7 @@
                     <Patch Id="BVlPwYtv5nWLq0E06bV3h8" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="DSCbyvx7GgUPqtZB4anEv0" Name="Then" ManuallySortedPins="true" />
                     <Node Bounds="576,355,105,19" Id="HIOUnOD49xFPKreBA1T0yk">
-                      <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.vl" LastDependency="VL.Stride.vl">
+                      <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="TextureAspectRatio" />
                       </p:NodeReference>
@@ -4222,7 +4203,7 @@
                       <Pin Id="HFoBqf2kFT9McTwZzDAjNx" Name="Transformation" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="327,346,185,19" Id="Ayfm49wwBJ5NPmNMjmtctT">
-                      <p:NodeReference LastCategoryFullName="Stride.Graphics" LastSymbolSource="VL.Stride.Graphics.Nodes">
+                      <p:NodeReference LastCategoryFullName="Stride.Graphics" LastDependency="VL.Stride.Graphics.Nodes">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessNode" Name="SamplerState" />
                       </p:NodeReference>
@@ -4239,12 +4220,12 @@
                       <Pin Id="Hl15FC05Q2DPGHO0AjHvce" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Pad Id="TSAwh0CUW0dM5NV6YoXytc" Comment="Address V" Bounds="373,261,79,15" ShowValueBox="true" isIOBox="true" Value="Border">
-                      <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastSymbolSource="Stride.dll">
+                      <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.dll">
                         <Choice Kind="TypeFlag" Name="TextureAddressMode" />
                       </p:TypeAnnotation>
                     </Pad>
                     <Node Bounds="407,316,108,19" Id="UHpsGwBP7BML2v80o82brn">
-                      <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl" LastDependency="VL.Stride.vl">
+                      <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="ToDeviceColorSpace" />
                       </p:NodeReference>
@@ -4252,7 +4233,7 @@
                       <Pin Id="AYDpRDInBfYNZk7WEyBGyq" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="327,398,316,19" Id="NDoO1nMnlTwLWA3hZPGwPG">
-                      <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastSymbolSource="vl)">
+                      <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="vl">
                         <Choice Kind="ProcessNode" Name="ConstantShader (TextureTransform)" />
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       </p:NodeReference>
@@ -4267,7 +4248,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="120,149,65,19" Id="ACaaaFKFiJ8NS4CNqaTe0C">
-                  <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                   </p:NodeReference>
@@ -4276,7 +4257,7 @@
                   <Pin Id="RWNVwNQzbXBPLv0h1XzhS6" Name="Not Assigned" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="181,566,186,104" Id="DG1aTo5hyqJMgnpcqzKrM5">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -4288,7 +4269,7 @@
                     <Patch Id="Teg6ES3R2kNOZyBOsJSOk3" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="RPPF8XGH7CQNOaVTi23bZ7" Name="Then" ManuallySortedPins="true" />
                     <Node Bounds="193,607,112,19" Id="IIwdnsKbPvlOEqeEFMSUCO">
-                      <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+                      <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessNode" Name="ConstantColorShader" />
                       </p:NodeReference>
@@ -4301,14 +4282,14 @@
                 </Node>
                 <ControlPoint Id="MT7DXcJH2moMOHno6daR84" Bounds="196,899" />
                 <Node Bounds="309,778,145,19" Id="AvqgoLon8iuOtAuGPhBlnG">
-                  <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                  <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.Rendering.Nodes">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="PlaneMesh" />
                   </p:NodeReference>
                   <Pin Id="G3hGhwaPVfJPuTONrfQ2pc" Name="Size" Kind="InputPin" />
                   <Pin Id="EbksWixrMIoMRNuXTDEo8X" Name="Tessellation" Kind="InputPin" />
                   <Pin Id="GCnhjPkFW7nNYAMMhVLqDt" Name="Normal" Kind="InputPin" DefaultValue="UpZ">
-                    <p:TypeAnnotation LastCategoryFullName="Stride.Graphics.GeometricPrimitives" LastSymbolSource="Stride.Graphics.dll">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.Graphics.GeometricPrimitives" LastDependency="Stride.Graphics.dll">
                       <Choice Kind="TypeFlag" Name="NormalDirection" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -4389,7 +4370,7 @@
                 <Pin Id="T4kWKwIVXO2NE9AlYRv001" Name="Texture" Kind="InputPin" />
                 <Pin Id="FEOwq38zs04MqX2WK7wzQE" Name="Texture Transformation" Kind="InputPin" Bounds="615,134" />
                 <Pin Id="N4lqGDLLLwJLbKdPTrhEbA" Name="Color" Kind="InputPin" Bounds="561,29" DefaultValue="1, 1, 1, 1">
-                  <p:TypeAnnotation LastCategoryFullName="Color" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="RGBA" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -4397,19 +4378,19 @@
                 <Pin Id="Oyr0y90eRDSOh0cT8fVWtU" Name="Rasterizer State" Kind="InputPin" Bounds="513,584" />
                 <Pin Id="H5ko1bP1HlTMe3IZ5rEhsL" Name="Depth Stencil State" Kind="InputPin" Bounds="545,622" />
                 <Pin Id="NejruBAJhVQM4RDI03LzuN" Name="Aspect Ratio Correction Mode" Kind="InputPin" Bounds="568,204" DefaultValue="FitIn">
-                  <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="SizeMode" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="Sfx3APgjwUpLKjpIAGISEV" Name="Anchor" Kind="InputPin" Bounds="595,226" DefaultValue="Center">
-                  <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="RectangleAnchor" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="NAnM53CAsdQQMpGE2cf8fj" Name="Filter" Kind="InputPin" Bounds="331,102" />
                 <Pin Id="P11v5gQ40B0PZ6ZfLqLIoJ" Name="Address Mode" Kind="InputPin" Bounds="865,202" />
                 <Pin Id="EZDiK0OYLQcPEcmUW2O4qP" Name="BorderColor" Kind="InputPin" Bounds="979,212" DefaultValue="1, 1, 1, 0">
-                  <p:TypeAnnotation LastCategoryFullName="Color" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="RGBA" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -4434,7 +4415,7 @@
             <Canvas Id="TUtLLA1rXbnNK0yfXDgpwW" CanvasType="Group">
               <ControlPoint Id="BeHmPIz5j4LOJHHbmISElO" Bounds="139,35" />
               <Node Bounds="74,200,281,428" Id="BYeTXzf3MpXL7ANExgEPqD">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <FullNameCategoryReference ID="Primitive" />
@@ -4444,7 +4425,7 @@
                   <Patch Id="Of0R3fE2n8tNkvYghR6Eir" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="JEfeQSCAn9DMQdQ65WEfJ3" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="168,589,85,19" Id="PK4fBnHo5y9MPdtzW94Mb9">
-                    <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="UdpClient" />
                     </p:NodeReference>
@@ -4456,7 +4437,7 @@
                     <Pin Id="DTCz2ckn5DaO9JeELjPlbv" Name="Is Open" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="138,261,62,19" Id="J5jFgufJkeMLBjxetJjt3v">
-                    <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Matrix" />
                       <Choice Kind="OperationCallFlag" Name="GetValues" />
@@ -4465,7 +4446,7 @@
                     <Pin Id="KdYQiTaq21mOaFAekiGENw" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="247,261,62,19" Id="SEdekiObtwzLczHQtNNX3e">
-                    <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Matrix" />
                       <Choice Kind="OperationCallFlag" Name="GetValues" />
@@ -4474,7 +4455,7 @@
                     <Pin Id="RgxGeTXNjfQQGwGimJF3pN" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="138,299,114,19" Id="SUUuQYeY0qpOSG31WiHhcL">
-                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Concat" />
                       <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -4484,7 +4465,7 @@
                     <Pin Id="I2vqsWn9uHaNnJfMhhgeyN" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Node Bounds="126,345,187,126" Id="FbdCU2kkSCgPC5sXM0OYpP">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                       <FullNameCategoryReference ID="Primitive" />
@@ -4498,7 +4479,7 @@
                       <Patch Id="M4nFP3DfJOhOZasBe9ooYb" Name="Update" ManuallySortedPins="true" />
                       <Patch Id="EhqYpPUv62eQdiSj6DhYhu" Name="Dispose" ManuallySortedPins="true" />
                       <Node Bounds="211,392,90,19" Id="Lp1Y5N4XczXMld1URmlkwu">
-                        <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetFloat32Bytes" />
                         </p:NodeReference>
@@ -4506,7 +4487,7 @@
                         <Pin Id="QL3HHSKmWjGN8LtkOwQ4Nv" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="168,426,48,19" Id="PPZ06m6R5rkNjSY9nXbx8x">
-                        <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Concat" />
                           <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -4518,12 +4499,12 @@
                     </Patch>
                   </Node>
                   <Pad Id="Gy1lHCnF8MoNRyr3HmSPWh" Comment="Remote Port" Bounds="230,571,35,15" ShowValueBox="true" isIOBox="true" Value="5858">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="Integer32" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="188,494,99,19" Id="SCs4RVvh3DwPDREhDSjk2D">
-                    <p:NodeReference LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="SequenceChanged" />
                     </p:NodeReference>
@@ -4532,7 +4513,7 @@
                     <Pin Id="D6hxck5iZqwOatssaVvX52" Name="Unchanged" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="138,223,114,19" Id="BoXICxxNHIvMkWKPFLlCLU">
-                    <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Addons.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Addons.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="AsBetaCamera" />
                     </p:NodeReference>
@@ -4541,7 +4522,7 @@
                     <Pin Id="A8M9QVBV0l8PQS3CVr3x0X" Name="Projection" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="188,526,54,19" Id="UcaLIHSatfmQTOyqtMG0TB">
-                    <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="OnOpen" />
                     </p:NodeReference>
@@ -4551,7 +4532,7 @@
                 </Patch>
               </Node>
               <Node Bounds="74,105,65,19" Id="RYeiuBUtXCxOZz28lyMUGU">
-                <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                 </p:NodeReference>
@@ -4561,7 +4542,7 @@
               </Node>
               <ControlPoint Id="PAgl0JYcnPRN5EV7iJ2R9D" Bounds="233,34" />
               <Node Bounds="74,158,37,19" Id="R50vLFlRRPBMKo2LYih9Mq">
-                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AND" />
                 </p:NodeReference>
@@ -4613,18 +4594,18 @@
 
 -->
         <Node Name="AsBetaCamera" Bounds="112,265,444,570" Id="SsHBO8KXtuGNGdjNXaD0iy">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="Viu40YrhBnuMT7vFKxG6QN">
             <Node Bounds="476,539,68,19" Id="Cd0JYxDOyBbNVuIRMB4UAj">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Perspective (FOV)" />
               </p:NodeReference>
               <Pin Id="UBjVrClgjF4NuBz75aNV8Z" Name="FOV" Kind="InputPin" />
               <Pin Id="MSRshsteNWfNW1gMq0Ohh2" Name="Aspect" Kind="InputPin" DefaultValue="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -4633,7 +4614,7 @@
               <Pin Id="Jmg4nTEfuMHQCU17VIWHms" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="345,478,89,26" Id="GhCjDyIEG49LTDlaig7PFn">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="DegreeToCycles" />
               </p:NodeReference>
@@ -4644,7 +4625,7 @@
             <Pin Id="GfvT0010ECLN5DHxaomLcM" Name="Input" Kind="InputPin" Bounds="805,89" />
             <Link Id="Qf6Cjd225SwLEPE2cc2j3N" Ids="GfvT0010ECLN5DHxaomLcM,GQUgcFTsWsWOfFL1Bof9NI" IsHidden="true" />
             <Node Bounds="246,339,104,26" Id="Ax58q7eA9y0NEV5yzVI0OK">
-              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="CameraComponent" />
                 <Choice Kind="OperationCallFlag" Name="VerticalFieldOfView" />
@@ -4654,7 +4635,7 @@
               <Pin Id="O5TTkSXgYZlMACmDJtNCUy" Name="Vertical Field Of View" Kind="OutputPin" />
             </Node>
             <Node Bounds="459,406,85,26" Id="EXpxntzSnzRN9h5ap1eHDl">
-              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AspectRatio" />
                 <CategoryReference Kind="ClassType" Name="CameraComponent" NeedsToBeDirectParent="true" />
@@ -4665,7 +4646,7 @@
             </Node>
             <Link Id="MkAEG6T0Xp0PSBQ732Kcke" Ids="TLQ2mG3QsL3PLAHjt8xx6C,QjRiGekQCX0L5p5AB5ZoDt" />
             <Node Bounds="459,445,85,26" Id="HA6X5vasprgPd2pFC7RYwn">
-              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="CameraComponent" />
                 <Choice Kind="OperationCallFlag" Name="NearClipPlane" />
@@ -4677,7 +4658,7 @@
             <Link Id="FeRAPJh15BjP1GykMkWY1e" Ids="D0fajdQ0V3aNa3ZYn8CZqe,PDvAwQXAmd6LFHFK5cLqMs" />
             <Link Id="RAhK765LjYzOPzkyk6rVuZ" Ids="CG1dZ5SJGwdLXvqHPHBoXR,NEQcwB5YWuYMfqFJPN9hne" />
             <Node Bounds="459,478,85,26" Id="IUgCFyNdG2yOsz4SLhjikQ">
-              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="FarClipPlane" />
               </p:NodeReference>
@@ -4688,7 +4669,7 @@
             <Link Id="A6yEVFkO4QZNWroi7ANKvm" Ids="APwdooUWAl6MUUVHmAZP0k,CFhRLllO8kYLB4IIjPdlAr" />
             <Link Id="RyY0Md9U1kzLUWv9VFbuWm" Ids="KPmArUS8qZNMSOZ2siCilW,KP0EDD62cKVQICEU4fwjJt" />
             <Node Bounds="246,478,85,26" Id="BvlUvCxfGvxPUm8HqGseB0">
-              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+              <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="CameraComponent" />
                 <Choice Kind="OperationCallFlag" Name="ViewMatrix" />
@@ -4705,7 +4686,7 @@
             <Pin Id="KGixWwCL5O5Ot9kYoHY1WJ" Name="Projection" Kind="OutputPin" Bounds="1306,402" />
             <Link Id="KnULjSD3VCCMRBkQZ63e7H" Ids="AstLKvJo59vLRLoCAQFdsE,KGixWwCL5O5Ot9kYoHY1WJ" IsHidden="true" />
             <Node Bounds="124,547,69,26" Id="GgH5UAQizdFPZklyWhPQsP">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Decompose" />
               </p:NodeReference>
@@ -4717,7 +4698,7 @@
             </Node>
             <Link Id="Vh2ohXf7zMbQIrfinBsrx6" Ids="NjO51e2pTkpQUKOq8aw52h,OVUncPbQ8rhOVTuHkFxckE" />
             <Node Bounds="166,740,54,19" Id="U1ygRpH7itgMRZgSY0GT6b">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="Matrix" NeedsToBeDirectParent="true" />
                 <Choice Kind="OperationCallFlag" Name="Rotation (Vector3)" />
@@ -4726,7 +4707,7 @@
               <Pin Id="JRZ7p6X8A6sLeRzpd5ZNuZ" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="166,587,81,19" Id="CMff8ENF1cGNw3iyBfabSH">
-              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Quaternion" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="ToEulerAngles" />
               </p:NodeReference>
@@ -4737,7 +4718,7 @@
             </Node>
             <Link Id="IvCY3VesNm8MOji4fYr4GW" Ids="J1COULgCHz9P37T1lPataH,Hicfahh8fXmL5Ocj2IhWE7" />
             <Node Bounds="166,613,81,19" Id="TF9bmYkvTNMOyemvx8LZFT">
-              <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Vector3Type" Name="Vector3" />
                 <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
@@ -4750,7 +4731,7 @@
             <Link Id="Vg48LNExIukNxJ0KO13Gmw" Ids="QPq9ywpqzFGOf1I5hDk6wl,UBjVrClgjF4NuBz75aNV8Z" />
             <Link Id="JVv2hRmerdKNcgn9lzTfGh" Ids="T3yTFf5fkZtLqZRMjpbZVJ,MSRshsteNWfNW1gMq0Ohh2" />
             <Node Bounds="166,774,164,19" Id="CXjyWm0Q3D1Lgwu1EcQWNy">
-              <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Translate" />
                 <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -4762,7 +4743,7 @@
               <Pin Id="S1U5xyKVxQtMkNUMkUfbdk" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="326,593,97,26" Id="BUCgBaaYME8MF5tcpfXhOe">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TranslationVector" />
                 <CategoryReference Kind="RecordType" Name="Matrix" NeedsToBeDirectParent="true" />
@@ -4771,7 +4752,7 @@
               <Pin Id="S7WD9aoBjwhMoHZIfXYNU0" Name="Translation Vector" Kind="OutputPin" />
             </Node>
             <Node Bounds="326,703,25,19" Id="NgoXbxyHS9wQKTlYzu7vAP">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
@@ -4781,14 +4762,14 @@
             </Node>
             <Link Id="GZJQIof7xq8LNow7V7Dzje" Ids="S7WD9aoBjwhMoHZIfXYNU0,Tjde7PzKxb9OSv2kP75Rxx" />
             <Pad Id="AfJ5Nx0sGwOQLo0L0GxEZh" Comment="" Bounds="267,630,35,43" ShowValueBox="true" isIOBox="true" Value="-1, -1, 1">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="D3f0oJSB6afNo5jvmkWqts" Ids="AfJ5Nx0sGwOQLo0L0GxEZh,RfgkHWqR9VjM2ZXUlfoW77" />
             <Link Id="Uvd1jaaqhe2OpljnmtgEZ7" Ids="HLXdfRVFyyYMIIpm65qRdK,MP7SMe13PA5OE4s8Pskpcf" />
             <Node Bounds="326,566,42,19" Id="RRCjTq15pRBMK5q3FQBWe2">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Invert" />
                 <CategoryReference Kind="RecordType" Name="Matrix" NeedsToBeDirectParent="true" />
@@ -4805,7 +4786,7 @@
             <Link Id="Ia36fV73iGtOPRPbUxJNx4" Ids="C6gldfDD9mpOjFIDeUYgh7,Fl1qPFLq1MIOSfhU4OXJOv" />
             <Link Id="S3iJiH5OIH0NQw8EmibdUi" Ids="AtbyIMqkib6NPQeCrZnoT1,Pg5HGjIzDf4OJGeXV364wk" />
             <Node Bounds="166,703,25,19" Id="BkWcl94FrwDPFfxOfXBDbz">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
@@ -4818,7 +4799,7 @@
             <Link Id="VZwVRQ1mINnMhKk2kJPl2W" Ids="BNXDwcFohXjOaFKj0kIGyL,UW7HhKJNgEpO235intWU7S" />
             <Link Id="ECG8Y6ezWQCQKXNkO9lPvQ" Ids="JRZ7p6X8A6sLeRzpd5ZNuZ,K9AcPiJzVKXPAgYPFXNA6T" />
             <Node Bounds="166,301,85,26" Id="UBoo2Zu66IFOVb0472DA0W">
-              <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+              <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetComponent" />
                 <CategoryReference Kind="ClassType" Name="Entity" NeedsToBeDirectParent="true" />
@@ -4837,12 +4818,12 @@
 
 -->
         <Node Name="PinToCamera (Transform)" Bounds="1147,873,347,352" Id="PCaYBGjIg3EPtkMbQaq9q1">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="PmE0FHR1rogOa6ERToa8yJ">
             <Node Bounds="1297,1098,42,19" Id="RnxkHXyvkA0QH7nbB4KBfM">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Invert" />
                 <CategoryReference Kind="RecordType" Name="Matrix" NeedsToBeDirectParent="true" />
@@ -4851,7 +4832,7 @@
               <Pin Id="VrNpvWBsrafOjuHanrvt8K" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="1297,1127,58,19" Id="JfVe6WmITZJQUCBaORhGbF">
-              <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Translate" />
                 <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -4863,7 +4844,7 @@
               <Pin Id="BqZKaFQYEhbLOSbjOEJzd8" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="1350,1098,46,19" Id="Cz7eHM2eYmJNb1mSJ4HMR8">
-              <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Vector3Type" Name="Vector3" />
                 <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
@@ -4871,20 +4852,20 @@
               <Pin Id="TKjUJlXJz0dOtn6zljV7hA" Name="X" Kind="InputPin" />
               <Pin Id="Vibj7fd1o2QLon7a2Gjnr1" Name="Y" Kind="InputPin" />
               <Pin Id="TUnAvjDYHBhLuIxeHX6ptZ" Name="Z" Kind="InputPin" DefaultValue="-1.21">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Gjm80SW6EUJNhGZpzI4uWV" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="1391,1070,25,19" Id="QO9XOcPUktDPbaehWFFFIM">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
               <Pin Id="EZHD60jyPYhOnX95aqlU9J" Name="Input" Kind="InputPin" />
               <Pin Id="OeNyoFj1oLaOPUSEjO6dbh" Name="Input 2" Kind="InputPin" DefaultValue="-1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -4898,7 +4879,7 @@
             <ControlPoint Id="K5Z2ON549jiOb70qr6WQKu" Bounds="1432,1208" />
             <Link Id="UPgWGIxmvE3NxMxRFE6GL4" Ids="K5Z2ON549jiOb70qr6WQKu,HR6PpQrD1IlQGkbg7Bz51x" IsHidden="true" />
             <Node Bounds="1391,1010,55,19" Id="QnnDyheZlHRPyF6D4Lrxgk">
-              <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Addons.Stride.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Addons.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Distance (Frustum)" />
               </p:NodeReference>
@@ -4911,7 +4892,7 @@
             <Link Id="I1Rfh9T13sfLMZEoQmahBb" Ids="Mi3kZDHWICOLOxI5KOtYL6,EbZscBdBfdYOSio8Pot6zf" IsHidden="true" />
             <Link Id="A8f46ypFG73PhH6tSVJ8JF" Ids="EbZscBdBfdYOSio8Pot6zf,VS2I4mCs3KHPEqzakgYgxa" />
             <Node Bounds="1205,966,112,118" Id="AD3946MAl4jQCb9BcWG4Hz">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -4923,7 +4904,7 @@
                 <Patch Id="HdYMqrsHi6FMAjTEt6cYMn" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="SEGVmKNu4FPPLWX5tMi2Xt" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="1217,1037,85,26" Id="GedqguF6LigNSF1uaYpRn6">
-                  <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="CameraComponent" />
                     <Choice Kind="OperationCallFlag" Name="ViewMatrix" />
@@ -4933,7 +4914,7 @@
                   <Pin Id="FXVy1rILBiGOX1RuoZniZt" Name="View Matrix" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1220,995,85,26" Id="NyAOMUFPDUPLQKXYw6p0zX">
-                  <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="GetComponent" />
                     <CategoryReference Kind="ClassType" Name="Entity" NeedsToBeDirectParent="true" />
@@ -4946,7 +4927,7 @@
             </Node>
             <Link Id="SI1FsLi4xlQPRzp2APmSrK" Ids="DsgUVFojUQPLF3gOflT90p,V43awLdbXaGNNHDfbm0lR9" />
             <Node Bounds="1205,930,65,19" Id="V2ltGigF6wkPVRktEdcKX1">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                 <CategoryReference Kind="ClassType" Name="Object" NeedsToBeDirectParent="true" />
@@ -4964,7 +4945,7 @@
             <Link Id="LJvl387Lr79PbrT9GIWj2P" Ids="F0yAlNVX02rLmBu3b8H32N,ECxV33Ii08cNU1fZkaKgf4" />
             <Link Id="AEdxJxL0ng3PIYZz8whPmC" Ids="KuFwifd2G7sP3veBikW264,F0yAlNVX02rLmBu3b8H32N" IsHidden="true" />
             <Node Bounds="1238,1169,64,19" Id="HsB3BTNzEbPNVDJAUUSg1C">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Transform" />
                 <CategoryReference Kind="RecordType" Name="Matrix" NeedsToBeDirectParent="true" />
@@ -4994,14 +4975,14 @@
 
 -->
         <Node Name="Height (Frustum)" Bounds="735,267,316,537" Id="IWap5Is5wgOLZ1dFh0HgAp">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="NX8U2wrsWRBLRcVWkEyEIx">
             <ControlPoint Id="UnrJ811G5WVO1UproP35MN" Bounds="749,285" />
             <Link Id="SoR8D1myxSyQdCs5H3RPiw" Ids="K8WeU6iyXTBLSnNmLtkYqQ,UnrJ811G5WVO1UproP35MN" IsHidden="true" />
             <Node Bounds="816,680,33,19" Id="JqnVC8I7j8ILwvQbx1wv46">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Tan" />
               </p:NodeReference>
@@ -5009,7 +4990,7 @@
               <Pin Id="JEZzS7WIfY0PQvtzzAsrEg" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="747,739,25,19" Id="MdkClHZ847HL7HE96dsCw2">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
@@ -5022,13 +5003,13 @@
             <ControlPoint Id="E4mboW4X3xNOn4JI1Wb3de" Bounds="797,371" />
             <Link Id="OsbyI8LtD3kMAU2AOFIJUq" Ids="HdNirTEA05QQcm6sc1SxWj,E4mboW4X3xNOn4JI1Wb3de" IsHidden="true" />
             <Node Bounds="747,691,25,19" Id="TDJRRdOfERZOrkiaELZUoq">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="* (Scale)" />
               </p:NodeReference>
               <Pin Id="AHwE0dXWiK5Ll9oBNMKkgY" Name="Input" Kind="InputPin" />
               <Pin Id="C09L6mfwfIsPnnMGV7trYX" Name="Scalar" Kind="InputPin" DefaultValue="2">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -5039,7 +5020,7 @@
             <Link Id="Qx6Mgog8bXoOGlLbQXCgiq" Ids="JEZzS7WIfY0PQvtzzAsrEg,PTPVSjNJk37O39LSfrc162" />
             <Link Id="VkJJxWhcb4eOskSRmZ3Or3" Ids="Axo6uEa2p0YLhfoRALXxpX,IwYQoQUka4vOzK6SILK53P" />
             <Node Bounds="939,631,100,19" Id="JCGJEI8BmWnLBE5X4sT3wv">
-              <p:NodeReference LastCategoryFullName="Stride.Core.Mathematics.MathUtil" LastSymbolSource="Stride.Core.Mathematics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Core.Mathematics.MathUtil" LastDependency="Stride.Core.Mathematics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="DegreesToRadians" />
               </p:NodeReference>
@@ -5047,13 +5028,13 @@
               <Pin Id="I1GiXDLd0ywMSPMaSMQYaw" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="938,605,25,19" Id="HSyf2qMiLLEO9UIQK03692">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
               <Pin Id="Czlge10eIlIQOaSBJCbbSh" Name="Input" Kind="InputPin" />
               <Pin Id="AnjCWCYSmSdNIleW1MwmZO" Name="Input 2" Kind="InputPin" DefaultValue="0.5">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -5062,7 +5043,7 @@
             <Link Id="MhGFb7l6BMDLiIF1rv4Msf" Ids="B4GvcQmUExbNe0206boDY2,UZvuuEORCxMPj3lIH9QdoA" />
             <Link Id="M2DD8NrG06QM3VMZe7iaRb" Ids="I1GiXDLd0ywMSPMaSMQYaw,S7xlxZuFqNjOQU6BBlFB5y" />
             <Node Bounds="795,468,162,125" Id="LiHhkRMjxzpOuVc5ujNCYq">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -5074,7 +5055,7 @@
                 <Patch Id="MuZXAPZkhsOLolsobOji3l" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="GWsEttmZNcaMwCh03VkTbp" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="807,496,85,26" Id="MMNdLQPHrGqQVsyS84qnVo">
-                  <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="GetComponent" />
                     <CategoryReference Kind="ClassType" Name="Entity" NeedsToBeDirectParent="true" />
@@ -5084,7 +5065,7 @@
                   <Pin Id="CdByH05lFW4ND8OvO0XLMm" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="824,540,119,26" Id="GXJc2c8OuycPbPKytw7lvR">
-                  <p:NodeReference LastCategoryFullName="Stride.Engine.CameraComponent" LastSymbolSource="Stride.Engine.dll">
+                  <p:NodeReference LastCategoryFullName="Stride.Engine.CameraComponent" LastDependency="Stride.Engine.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="VerticalFieldOfView" />
                     <CategoryReference Kind="AssemblyCategory" Name="CameraComponent" NeedsToBeDirectParent="true" />
@@ -5096,7 +5077,7 @@
               </Patch>
             </Node>
             <Node Bounds="795,403,65,19" Id="CdlCRUbHdbQODeh6nOgLHe">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                 <CategoryReference Kind="ClassType" Name="Object" NeedsToBeDirectParent="true" />
@@ -5113,7 +5094,7 @@
             <Link Id="ByFPiCnBBpyOHqLxwjKUaR" Ids="E4mboW4X3xNOn4JI1Wb3de,NWn6oLxkd2uMGGDvePs2lO" />
             <Link Id="COrRREkFW8VPSFocGs38sG" Ids="P6ulApt6U8IOkSleEr8Pjl,Czlge10eIlIQOaSBJCbbSh" />
             <Pin Id="K8WeU6iyXTBLSnNmLtkYqQ" Name="Distance" Kind="InputPin" DefaultValue="1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -5136,14 +5117,14 @@
 
 -->
         <Node Name="Distance (Frustum)" Bounds="1093,278,362,419" Id="Auz4xUbxB3RNmEtMl0kHqc">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="CzsVZMCedSKQSXpOkbsfl9">
             <ControlPoint Id="LBgNoOz3DINNgfG6V47KQQ" Bounds="1107,299" />
             <Link Id="V2V0e4tkAhcOxy8gnYxEpy" Ids="D85TB9V2fQvOuGD5IfQEhN,LBgNoOz3DINNgfG6V47KQQ" IsHidden="true" />
             <Node Bounds="1344,602,33,19" Id="HJSYu7vSzlINlnYFrO8gXy">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Tan" />
               </p:NodeReference>
@@ -5151,13 +5132,13 @@
               <Pin Id="NQcDmN8D9FRNFABeiTpDKP" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="1344,571,25,19" Id="OLNJUAOY70iNpzYi2WhuXf">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
               <Pin Id="LYcRTkVsYh5N8J2Q1INOhg" Name="Input" Kind="InputPin" />
               <Pin Id="DOnFEhg0JefQZ9ZyScqsHj" Name="Input 2" Kind="InputPin" DefaultValue="0.5">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -5165,7 +5146,7 @@
             </Node>
             <Link Id="Ez8nGE6kwvrMaXwXSNKO4p" Ids="HKXMVtAZBF3NRcvPbhb0Tt,QQr8utHDn7wQOnJGQ04Xbs" />
             <Node Bounds="1324,641,25,19" Id="OZaadakS7jvP2I5GOTlqRl">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="/" />
               </p:NodeReference>
@@ -5175,7 +5156,7 @@
             </Node>
             <Link Id="SCzP0E3LovrOJMXjzPAf3j" Ids="NQcDmN8D9FRNFABeiTpDKP,VpZUR6weHEhNJBcnam3tPj" />
             <Node Bounds="1260,586,25,19" Id="VZJmQRyiRtmPsm344uM5pL">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
@@ -5185,7 +5166,7 @@
             </Node>
             <Link Id="IrGtE2xLuVHO5NLWCwuVFc" Ids="AAOd1b2VpCPOuIzRxGjJtW,JVYUTifu5myN7Jn2amQyTK" />
             <Pad Id="ATLKy6wfNoVLQbavfRRNlW" Comment="" Bounds="1282,558,35,15" ShowValueBox="true" isIOBox="true" Value="0.5">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
@@ -5198,7 +5179,7 @@
             <Link Id="BNVKXRt6IzxLFFcDgfpIg7" Ids="E7ZDRJbe8QaNkmbdUDBuVN,Cf8JauhysHpP3HYtas8s0z" />
             <Link Id="Mpr2UO3DduZPM3otoxGKrU" Ids="LBgNoOz3DINNgfG6V47KQQ,C0CUKoX3I9iNxqC158jW9h" />
             <Node Bounds="1200,398,162,124" Id="TDaPECazoFnPbIPIyA5HIB">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -5210,7 +5191,7 @@
                 <Patch Id="MPO453ql9KILyfS84jLRnE" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="CKOaZt9Nc5ANWCaxMJh7FU" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="1212,425,85,26" Id="AKC8UG2eOeaNSaGUEsL1FG">
-                  <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="GetComponent" />
                     <CategoryReference Kind="ClassType" Name="Entity" NeedsToBeDirectParent="true" />
@@ -5220,7 +5201,7 @@
                   <Pin Id="N36FQVD6NwyMEh9CiiRqPK" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1229,469,119,26" Id="RSFkCEpAciEOkYfEixO53A">
-                  <p:NodeReference LastCategoryFullName="Stride.Engine.CameraComponent" LastSymbolSource="Stride.Engine.dll">
+                  <p:NodeReference LastCategoryFullName="Stride.Engine.CameraComponent" LastDependency="Stride.Engine.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="VerticalFieldOfView" />
                     <CategoryReference Kind="AssemblyCategory" Name="CameraComponent" NeedsToBeDirectParent="true" />
@@ -5232,7 +5213,7 @@
               </Patch>
             </Node>
             <Node Bounds="1200,332,65,19" Id="DNKxkT2qKUSOi79GHLsNzh">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                 <CategoryReference Kind="ClassType" Name="Object" NeedsToBeDirectParent="true" />
@@ -5247,7 +5228,7 @@
             <Link Id="GXGKBxUqXovLzSpOikfhyl" Ids="N36FQVD6NwyMEh9CiiRqPK,K5BdPbnSIm3OFrEIGeOmQH" />
             <Link Id="CBCQJZgj5FfN8OCLcdZM34" Ids="Q4rThF4PkbNPtWAxpG0SxX,JXEPm6Za71GPkESrQwUln6" />
             <Node Bounds="1343,543,100,19" Id="BbeqqDjQN2uO1hJyXtH8GR">
-              <p:NodeReference LastCategoryFullName="Stride.Core.Mathematics.MathUtil" LastSymbolSource="Stride.Core.Mathematics.dll">
+              <p:NodeReference LastCategoryFullName="Stride.Core.Mathematics.MathUtil" LastDependency="Stride.Core.Mathematics.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="DegreesToRadians" />
               </p:NodeReference>
@@ -5257,7 +5238,7 @@
             <Link Id="PzwQBplDmaTQSws4NC6bbi" Ids="JXEPm6Za71GPkESrQwUln6,Mle3056YsuvL1xUTXNiCZd" />
             <Link Id="PmSt8shRcV6NnlVuC6zJB0" Ids="F0fXQAVUOswO6kqmVuZXbx,LYcRTkVsYh5N8J2Q1INOhg" />
             <Pin Id="D85TB9V2fQvOuGD5IfQEhN" Name="Height" Kind="InputPin" DefaultValue="1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -5271,12 +5252,12 @@
 
 -->
         <Node Name="ScaleToCamera (Transform)" Bounds="738,860,350,365" Id="Vu6OxuSLsWALiUWOnawUT0">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="Johq8P69VdOPStnMtnoDEz">
             <Node Bounds="888,1085,42,19" Id="EZ1K3TZp0YGOtHvDhNS1sN">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Invert" />
                 <CategoryReference Kind="RecordType" Name="Matrix" NeedsToBeDirectParent="true" />
@@ -5285,7 +5266,7 @@
               <Pin Id="HYBzFyfvdDbLQGZGQwv0Ke" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="888,1115,58,19" Id="AN9rCIMbg1QL884gC4VbKi">
-              <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Translate" />
                 <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -5297,7 +5278,7 @@
               <Pin Id="F3RDBXODuccM2895BHnFuk" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="941,1085,46,19" Id="QWdIsr1GskbOLiPwHlt8PG">
-              <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Vector3Type" Name="Vector3" />
                 <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
@@ -5305,7 +5286,7 @@
               <Pin Id="DrAeLUg2V7VNGcjmwrnkT4" Name="X" Kind="InputPin" />
               <Pin Id="DUtu1G1UYPWMOx7Fp72Fqt" Name="Y" Kind="InputPin" />
               <Pin Id="KvJTx8CXqIBOIfDv6N95bq" Name="Z" Kind="InputPin" DefaultValue="-1.21">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -5316,7 +5297,7 @@
             <ControlPoint Id="GB8vAMOF5PPO31eGEd4jn6" Bounds="831,1208" />
             <Link Id="DnKnjUosJBCORdCzhf1luC" Ids="GB8vAMOF5PPO31eGEd4jn6,VBkIbbWfAnGPfIuffgHAOy" IsHidden="true" />
             <Node Bounds="1016,1085,55,19" Id="NrtNXdDgNqVQDiHNiTOwin">
-              <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Addons.Stride.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Addons.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Height (Frustum)" />
               </p:NodeReference>
@@ -5329,7 +5310,7 @@
             <Link Id="Huq69MZ4TJ7OJtrQdkbRv5" Ids="MfyLJzLFNM9M4857oE4JsZ,Ke55hjpIPmhQEdQe7vil53" IsHidden="true" />
             <Link Id="NLnasLiBkpQQdTZrYCaZxh" Ids="Ke55hjpIPmhQEdQe7vil53,TkNRPLB1cKpPrBZkTtPkEV" />
             <Node Bounds="796,956,112,117" Id="RTU1VjJFcpgNENJbn6f9Aj">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -5341,7 +5322,7 @@
                 <Patch Id="JgK3H10Kz1RPPt9QdWxD6K" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="PlAayTqm9kSLu7iiojY9es" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="808,1024,85,26" Id="C8x2tylbETtNEymaPBMwVH">
-                  <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="CameraComponent" />
                     <Choice Kind="OperationCallFlag" Name="ViewMatrix" />
@@ -5351,7 +5332,7 @@
                   <Pin Id="DfKTRbVFWioMX1An2s9xjN" Name="View Matrix" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="811,982,85,26" Id="Tq6wsZaxlsVNbPgR4QSXjd">
-                  <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Engine.Entity" LastDependency="VL.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="GetComponent" />
                     <CategoryReference Kind="ClassType" Name="Entity" NeedsToBeDirectParent="true" />
@@ -5364,7 +5345,7 @@
             </Node>
             <Link Id="LxTa87hsUCuMKokJQUahjV" Ids="DVau4lUhN3oPhCIu7DkjGs,OgI9ntDoRi8LDd9sDx5iiM" />
             <Node Bounds="796,917,65,19" Id="OxDSRx8AmsrPgAKRAV7Q1Z">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                 <CategoryReference Kind="ClassType" Name="Object" NeedsToBeDirectParent="true" />
@@ -5381,7 +5362,7 @@
             <ControlPoint Id="BQ9jy0g89ThMIxKQKzcWS4" Bounds="986,878" />
             <Link Id="CCOJsD11XI6Md33pEuvvGJ" Ids="E0lLMyTP8u1NCCSOr7ORcE,BQ9jy0g89ThMIxKQKzcWS4" IsHidden="true" />
             <Node Bounds="829,1173,64,19" Id="PhRVHrDMATBLskXx0UL5CC">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Transform" />
                 <CategoryReference Kind="RecordType" Name="Matrix" NeedsToBeDirectParent="true" />
@@ -5397,7 +5378,7 @@
             <Link Id="Qn2p3TWlcsTN4i2D7UyUuG" Ids="BQ9jy0g89ThMIxKQKzcWS4,SKxWOMvrt9wOdKGjJO0qjA" />
             <Link Id="TG8WYmswqRJOmW2oAM0DBB" Ids="BQ9jy0g89ThMIxKQKzcWS4,KvJTx8CXqIBOIfDv6N95bq" />
             <Node Bounds="888,1146,134,19" Id="TDcJg6NQnpwPTfeW71gywe">
-              <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="UniformScale" />
                 <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -5427,18 +5408,18 @@
 
 -->
         <Node Name="CameraTransforms" Bounds="117,909,469,796" Id="SFIOHsuH1riNuzO9OUgqRs">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="SlNqrOobPeaObsaImX778u" ManuallySortedPins="true">
             <Pad Id="U0lJ4liz1ANNbvNv4DYBiW" Comment="Aspect" Bounds="264,1540,33,15" ShowValueBox="true" isIOBox="true" Value="1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="Nu27HfMj53GLoAMioHSVpW" Comment="Min" Bounds="302,1013,46,15" ShowValueBox="true" isIOBox="true" Value="-0.249899909">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
@@ -5447,7 +5428,7 @@
               </p:ValueBoxSettings>
             </Pad>
             <Pad Id="NaZtdZAELz9QAv9MslsnUs" Comment="Max" Bounds="322,1035,41,15" ShowValueBox="true" isIOBox="true" Value="0.249900028">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
@@ -5456,19 +5437,19 @@
               </p:ValueBoxSettings>
             </Pad>
             <Pad Id="SayRTuhwzJ9LZQJj4LAmgX" Comment="Scalar" Bounds="243,956,46,15" ShowValueBox="true" isIOBox="true" Value="-1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="RYcC6xIsrx5L6wtSBr4uwg" Bounds="322,1114,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="406,1567,42,19" Id="T3CHZ1d6YsaPWmxI38JPlE">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Invert" />
                 <CategoryReference Kind="Category" Name="Matrix" />
               </p:NodeReference>
@@ -5476,7 +5457,7 @@
               <Pin Id="NAR4YJaQfHTLFfFfE9pDNQ" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="241,1567,68,19" Id="T2uUr4h62zdNNsLM9l6WMM">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Perspective (FOV)" />
                 <CategoryReference Kind="Category" Name="Matrix" />
               </p:NodeReference>
@@ -5487,7 +5468,7 @@
               <Pin Id="HSuidL8RiGzQbVuLzrhr7G" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="280,1047,45,19" Id="EYrVr8PiLauO1oQuecsbvK">
-              <p:NodeReference LastCategoryFullName="Math.Ranges" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Clamp" />
                 <CategoryReference Kind="Category" Name="Ranges" />
               </p:NodeReference>
@@ -5497,7 +5478,7 @@
               <Pin Id="Ap0Oia77LhKNk00ywdzjwz" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="280,1172,46,19" Id="OpEqHDGUawdOQJI2v9VhPv">
-              <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Vector (Join)" />
                 <CategoryReference Kind="Category" Name="Vector3" />
               </p:NodeReference>
@@ -5507,7 +5488,7 @@
               <Pin Id="E6DhUkMoAcEObyUDUoQkUZ" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="240,1206,45,19" Id="SYBRS8m9ZDsNxu7XmsSJz5">
-              <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Rotate" />
                 <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
                   <p:OuterCategoryReference Kind="Category" Name="3D" NeedsToBeDirectParent="true" />
@@ -5518,7 +5499,7 @@
               <Pin Id="CYwnas3lik9QZkLzGYd45S" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="313,1313,67,19" Id="LUhQLwMTBBZQNP6QUaupS6">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Translation" />
                 <CategoryReference Kind="Category" Name="Matrix" />
               </p:NodeReference>
@@ -5526,7 +5507,7 @@
               <Pin Id="SpuqTzs2NryMa6WoLiWItB" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="313,1279,46,19" Id="UIcISCwEmOvL9bRQ9thQJU">
-              <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Vector (Join)" />
                 <CategoryReference Kind="Category" Name="Vector3" />
               </p:NodeReference>
@@ -5536,7 +5517,7 @@
               <Pin Id="V22zhm0tg1WOtohK72ODWG" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="240,1240,42,19" Id="U8c9An9RpTpN4iajYAjBmT">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Invert" />
                 <CategoryReference Kind="Category" Name="Matrix" />
               </p:NodeReference>
@@ -5544,7 +5525,7 @@
               <Pin Id="GltXAy61oerMQp16jrqKf6" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="221,1271,67,19" Id="HMRpUtbh0o9MZ2hXhaEHh7">
-              <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Translation" />
                 <CategoryReference Kind="Category" Name="Matrix" />
               </p:NodeReference>
@@ -5552,7 +5533,7 @@
               <Pin Id="PHT96QFbBX5MJ5C59kzYgA" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="221,1312,25,19" Id="L1jYBJqbCy8LmjJ2Anwrm4">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="*" />
               </p:NodeReference>
               <Pin Id="P7AKKLvHPZkOnBLE7K6Qke" Name="Input" Kind="InputPin" />
@@ -5560,7 +5541,7 @@
               <Pin Id="FD4TNDSX6O0P6qJFMyAiLe" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="221,1347,97,19" Id="PJqJKJ2ybqCPoIYz8JmDDV">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="*" />
               </p:NodeReference>
               <Pin Id="Ifjobs5Vd8gOxLM1C5yQpZ" Name="Input" Kind="InputPin" />
@@ -5568,7 +5549,7 @@
               <Pin Id="RNABqDt8BTZLqe0N3n8ICj" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="221,1651,25,19" Id="D3ub4fQgyHwQYdsDWAmAeq">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="*" />
               </p:NodeReference>
               <Pin Id="TLWRyTlgnkGNEPE72TA4RC" Name="Input" Kind="InputPin" />
@@ -5576,7 +5557,7 @@
               <Pin Id="EwjslvfajyZPwobaY605W5" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="510,1621,64,19" Id="T7Ofl8OstohNrCrYKmgeem">
-              <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Transform" />
                 <CategoryReference Kind="Category" Name="Vector3" />
               </p:NodeReference>
@@ -5585,7 +5566,7 @@
               <Pin Id="DYk4wNYMPfFOJc3qzKheKY" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="221,972,25,19" Id="T8KZwfNFZruMLSjEcB2YKs">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="* (Scale)" />
               </p:NodeReference>
               <Pin Id="NB8EeaTM9BDMbRxOAzhtoS" Name="Input" Kind="InputPin" />
@@ -5593,7 +5574,7 @@
               <Pin Id="Gl26kPYWMqAM3aw3Xib0wO" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="300,1131,25,19" Id="LzdQLtBPpgnLHwP1zxg4ju">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="*" />
               </p:NodeReference>
               <Pin Id="L0bFDpkYophPxiUiwgJlKX" Name="Input" Kind="InputPin" />
@@ -5661,12 +5642,12 @@
             <Pin Id="AHYZ1VCgqaZNOX5fBG010N" Name="Distance" Kind="InputPin" />
             <Pin Id="IAPvVxJlkTcLF3TsJQoCnC" Name="FOV" Kind="InputPin" />
             <Pin Id="FRMbBeGxpDZNmBIKsDpISf" Name="Near Plane" Kind="InputPin" DefaultValue="0.01">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="Q1ohrFPmHLfLp4DNHxVHgl" Name="Far Plane" Kind="InputPin" DefaultValue="100">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -5683,13 +5664,13 @@
 
 -->
         <Node Name="SimpleCamera" Bounds="130,1772" Id="Sfkr5UNEFiCMkXiT6E1QrQ">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="IaQ5KFcxvMLL0flrcw0ZYT">
             <Canvas Id="CuOptQIEcHEP8ohzsf2ZJF" CanvasType="Group">
               <Node Bounds="109,249,125,19" Id="HCtMkmmu3FDOcT0FrEmipN">
-                <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Addons.Stride.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Addons.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="CameraTransforms" />
                 </p:NodeReference>
@@ -5708,7 +5689,7 @@
               </Node>
               <ControlPoint Id="GlJHSaAIOCaOJL5G3ZaIDd" Bounds="111,147" />
               <Node Bounds="193,392,265,19" Id="NE6GMXFa80jP1p5k9a4bIE">
-                <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+                <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="Camera" />
                   <CategoryReference Kind="Category" Name="Cameras" NeedsToBeDirectParent="true">
@@ -5784,27 +5765,27 @@
             <Patch Id="EXdn11l1ssmMH1gNoj4MZ1" Name="Update">
               <Pin Id="FRyss4iUyc3P3KeyRrZdNW" Name="Interest" Kind="InputPin" Bounds="302,258" />
               <Pin Id="GodKoKjUJwvOrXxCPuFQBA" Name="Yaw" Kind="InputPin" Bounds="337,364" DefaultValue="0">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="IbpeUn5ZnkQMFd5Pb9T40V" Name="Pitch" Kind="InputPin" Bounds="319,328" DefaultValue="-0.05">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="D9r9DZuhyWyOtR1gJ7lSoe" Name="Distance" Kind="InputPin" Bounds="398,327" DefaultValue="-5">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="D2P9lhCjqIMQJwxzk7G8no" Name="FOV" Kind="InputPin" Bounds="486,275" DefaultValue="0.125">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="KpukNbS1iajLh1cgnZ2trg" Name="Aspect Ratio" Kind="InputPin" Bounds="595,368" DefaultValue="1.777778">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -5832,7 +5813,7 @@
               <Canvas Id="IeVH9JziPqiPxOowQuG4OB" CanvasType="Group">
                 <Pad Id="KWXot0g6Q17OwxFywrq7Qq" SlotId="THmwek5P6eBMdjlF5zGu1H" Bounds="469,315" />
                 <Node Bounds="467,214,45,19" Id="R98S9lYdtidQOSGvqwFdYe">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Empty" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -5841,7 +5822,7 @@
                 </Node>
                 <Pad Id="ILyVlkGsbr5O7NQBNIRJWH" SlotId="THmwek5P6eBMdjlF5zGu1H" Bounds="602,281" />
                 <Node Bounds="600,299,81,26" Id="GQZvBZQLgCLLWJjBORirse">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Add" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -5858,7 +5839,7 @@
                 <ControlPoint Id="TfJeV9yD1LlLQsEC0w0TaI" Bounds="1057,401" />
                 <Pad Id="FT7Vsyyth5FLNDFElDKnzf" SlotId="THmwek5P6eBMdjlF5zGu1H" Bounds="1209,218" />
                 <Node Bounds="1208,301,41,26" Id="Lz6gYPUkeOxOW3rhgfdy0g">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Clear" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -5877,7 +5858,7 @@
                 <Pad Id="MRZekXRfeS0QHAzqaJDFJ1" SlotId="PFRHhNmb9sLNdVVOn9gNWN" Bounds="1666,217" />
                 <ControlPoint Id="THAJcOU9wWeMBHq30eAjvb" Bounds="1728,214" />
                 <Node Bounds="1410,294,84,86" Id="HRvXGi0hecJPdt6geoyQHk">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                     <FullNameCategoryReference ID="Primitive" />
@@ -5890,7 +5871,7 @@
                     <Patch Id="FFclVvNZPyDOI0zgLaP7PW" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="Hsa1p94jLz6QF1kbxtrPfW" Name="Then" ManuallySortedPins="true" />
                     <Node Bounds="1422,325,60,26" Id="SGa8B6BEZxOMUFXcXnk5Zw">
-                      <p:NodeReference LastCategoryFullName="System.Serialization" LastSymbolSource="System.Serialization.vl" LastDependency="VL.CoreLib.vl">
+                      <p:NodeReference LastCategoryFullName="System.Serialization" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="Category" Name="Serialization" NeedsToBeDirectParent="true" />
                         <Choice Kind="OperationCallFlag" Name="Serialize (Log Errors)" />
@@ -5898,7 +5879,7 @@
                       <Pin Id="TFXvfvySSU1Ok1RsjW9GXZ" Name="Value" Kind="InputPin" />
                       <Pin Id="QutlDcckpA9ORnbaRqIqrG" Name="Throw On Error" Kind="InputPin" />
                       <Pin Id="AQW2XbvhbbEN9w2QPjJUdj" Name="Include Defaults" Kind="InputPin" DefaultValue="True">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Boolean" />
                         </p:TypeAnnotation>
                       </Pin>
@@ -5908,7 +5889,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="1664,294,65,19" Id="PDgpv2Lh4ubONwfY98VjBJ">
-                  <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="Reactive" />
                     <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
@@ -5919,7 +5900,7 @@
                   <Pin Id="Rw687Xs6b56PJLr0mfS4zO" Name="On Data" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1627,346,115,76" Id="HXDPFP07SXpLTbALfrPrP7">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -5931,7 +5912,7 @@
                     <Patch Id="IqJg2JdEWUCNsizxI68j2n" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="R5pB9y644hMP37PjZtGzoF" Name="Then" ManuallySortedPins="true" />
                     <Node Bounds="1664,374,66,26" Id="KwKW2f18CZbN23xEjJWP2N">
-                      <p:NodeReference LastCategoryFullName="System.Serialization" LastSymbolSource="System.Serialization.vl" LastDependency="VL.CoreLib.vl">
+                      <p:NodeReference LastCategoryFullName="System.Serialization" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="Category" Name="Serialization" NeedsToBeDirectParent="true" />
                         <Choice Kind="OperationCallFlag" Name="Deserialize (Log Errors)" />
@@ -5952,7 +5933,7 @@
                   <p:Value />
                 </Pad>
                 <Node Bounds="803,296,65,26" Id="QwqY1WY2DQOOzCadeGp8fz">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetSlice" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -5961,7 +5942,7 @@
                   <Pin Id="LIQI6OHNlDyL5ZxAlQEoNF" Name="Value" Kind="InputPin" />
                   <Pin Id="OYJ8Wwzkx9rOX4fb9UV6cz" Name="Index" Kind="InputPin" />
                   <Pin Id="S2OPm203qYMNBWKItMTm1q" Name="Apply" Kind="InputPin" DefaultValue="False">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -5975,7 +5956,7 @@
                 </Pad>
                 <ControlPoint Id="VFnqWwt1WunPmOFVMZ9WyN" Bounds="865,232" />
                 <Node Bounds="1354,426,140,19" Id="OiElXG2LQvbLCHFVQLzhCQ">
-                  <p:NodeReference LastCategoryFullName="System.XML" LastSymbolSource="VL.Xml.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="System.XML" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="XMLWriter" />
                   </p:NodeReference>
@@ -5984,7 +5965,7 @@
                   <Pin Id="QOgISiFgyDwNxiaM6JJW0W" Name="Write" Kind="InputPin" />
                 </Node>
                 <Node Bounds="1664,253,67,19" Id="LmnYZEdQCuMLFuxa827tnP">
-                  <p:NodeReference LastCategoryFullName="System.XML" LastSymbolSource="VL.Xml.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="System.XML" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="XMLReader (Reactive)" />
                   </p:NodeReference>
@@ -6061,7 +6042,7 @@
               <Patch Id="RFrglybdzfvNzYHdTY5RNO" Name="Create" ParticipatingElements="R98S9lYdtidQOSGvqwFdYe" />
               <Patch Id="E1jqMc1Uxy2QK5Sz2Wt2Qp" Name="Update" ParticipatingElements="LcyqbEhbtInQVzkkES3Mjt">
                 <Pin Id="FJnHT4tjMdZOqGjZDMgrgV" Name="Path" Kind="InputPin" DefaultValue="..\\">
-                  <p:TypeAnnotation LastCategoryFullName="IO" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Path" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -6097,7 +6078,7 @@
 
 -->
             <Node Name="CameraModel" Bounds="401,378" Id="Mg69P0pizyhNa12JX3nSBo">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="RecordDefinition" Name="Record" />
               </p:NodeReference>
               <Patch Id="O5ZkLsNy3UQOXnOGvOTSVA">
@@ -6130,7 +6111,7 @@
                   <ControlPoint Id="EEfNyf8NXGELnhSpiyc4w8" Bounds="399,486" />
                   <ControlPoint Id="Cso5TEimVNlP799clvLCez" Bounds="1462,487" />
                   <Node Bounds="902,623,39,19" Id="TeHmTMCD9U6OXY9MMZiLPy">
-                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Cons" />
                       <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -6145,10 +6126,10 @@
                   </Node>
                   <Pad Id="Aeo8KZaQcmoL5HckX2UYAi" SlotId="CCjJgL7JciZNn20j33doeY" Bounds="904,677" />
                   <Pad Id="PVJsEWwcDQDMcOqQ7AegrN" Comment="" Bounds="1153,539,74,114" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 0, 0, 0">
-                    <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.Collections.vl">
                       <Choice Kind="TypeFlag" Name="Spread" />
                       <p:TypeArguments>
-                        <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </TypeReference>
                       </p:TypeArguments>
@@ -6294,7 +6275,7 @@
 
 -->
             <Node Name="CameraControlsModel" Bounds="400,447" Id="Ppr51I3OPqjOR2n8kN3zKf">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="RecordDefinition" Name="Record" />
               </p:NodeReference>
               <Patch Id="DjoX7gWliiMNLipEDBhEMR">
@@ -6312,7 +6293,7 @@
                   <ControlPoint Id="Dp469S3BTGmQaGB8qTTDc6" Bounds="1260,236" />
                   <ControlPoint Id="KVPUh5rz86YNqcmA1NaeVb" Bounds="1378,236" />
                   <Node Bounds="1376,261,37,19" Id="RBhDXvhJ1JjLwmk0IPQqx5">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="NOT" />
                     </p:NodeReference>
@@ -6326,7 +6307,7 @@
                   <ControlPoint Id="UWhkVJl53TkOaMRfS7bhSm" Bounds="1260,394" />
                   <ControlPoint Id="MFB47B5KfYVLWCczL5LQVJ" Bounds="1378,394" />
                   <Node Bounds="1376,345,37,19" Id="UGr5B3eVNMWLyMbXriz2nF">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="NOT" />
                     </p:NodeReference>
@@ -6340,7 +6321,7 @@
                   <Pad Id="Rq843WusTWpMmLehm9OMRG" SlotId="Qo1Y4FPnaLePlPZYxTWhua" Bounds="1233,532" />
                   <Pad Id="DCrjWSuHkZ8NOepUVrVTxu" SlotId="HadsMGYVAqBPTDiM3cykR6" Bounds="1351,532" />
                   <Node Bounds="674,622,25,19" Id="IBnUlnqXJYSPxLTsj2Hxvq">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -6361,7 +6342,7 @@
                   <Pad Id="FMOx6jjj9vzL85jTWh3d3l" SlotId="Qo1Y4FPnaLePlPZYxTWhua" Bounds="1212,752" />
                   <Pad Id="DSAAjdrTfKvLvNThHD4M4y" SlotId="HadsMGYVAqBPTDiM3cykR6" Bounds="1330,752" />
                   <Node Bounds="799,612,25,19" Id="CWRxoIWpeZjPdiXdvxXMyF">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -6370,7 +6351,7 @@
                     <Pin Id="TMvWLZpYqdwP9HDHORobvL" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="1079,621,25,19" Id="UcXuobfe8TbObMOqdTy3Y5">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -6379,7 +6360,7 @@
                     <Pin Id="BtYPVlwwJa7LyfbtYjotG4" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="523,617,25,19" Id="QO7IB8NwxKFPanX7ErmdE2">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -6388,7 +6369,7 @@
                     <Pin Id="Aj6Q4KDVxqNN4PlUaoBKBj" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="1207,620,30,19" Id="JA3dusyZtkGOIenCL0Lj0E">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="OR" />
                     </p:NodeReference>
@@ -6397,7 +6378,7 @@
                     <Pin Id="Qg8g3Q9LOw2Orj8KK7wF4z" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Node Bounds="1313,625,37,19" Id="HeOt5xFrIOnQCNgHYeT5pb">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="AND" />
                     </p:NodeReference>
@@ -6406,7 +6387,7 @@
                     <Pin Id="SQBOov4XYQmM3kelsKOX6Z" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Node Bounds="1354,589,37,19" Id="AlM8AP8XEplOzg6Yypchzv">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="NOT" />
                     </p:NodeReference>
@@ -6414,7 +6395,7 @@
                     <Pin Id="E0DYTrjv9E9MEC20f78ahq" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Node Bounds="1325,677,37,19" Id="JxQTKBEeKguNvStXNDxWjb">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="NOT" />
                     </p:NodeReference>
@@ -6426,7 +6407,7 @@
                   <ControlPoint Id="B9Jzd8l6mYiP23jtohRlBT" Bounds="975,240" />
                   <Pad Id="IneMIXN0yl3OqaRg78Xr14" SlotId="H0DuXw1o0n8Oafq6fgRexL" Bounds="958,533" />
                   <Node Bounds="934,609,25,19" Id="HeyHdItkC1BOqlknJuvjnN">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="+" />
                     </p:NodeReference>
@@ -6584,7 +6565,7 @@
                 <Canvas Id="LlbqXOR8Rw4LKkC8MlnoqR" CanvasType="Group">
                   <ControlPoint Id="D80laVAtmwXLRh6oZdE8el" Bounds="497,129" />
                   <Node Bounds="396,252,507,464" Id="UaqYccjar84P48rJFq2nKP">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <FullNameCategoryReference ID="Primitive" />
@@ -6598,7 +6579,7 @@
                       <Patch Id="VYETvwp28AyL7vBBp85UqB" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="A7DwYeAOns3Mln9hRIGQr7" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="429,311,72,19" Id="UJlI5zaetY1MCkIrRvFTqH">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="CameraView" />
                         </p:NodeReference>
@@ -6610,7 +6591,7 @@
                         <Pin Id="FWEGoEIXji3OA35FJwqoDG" Name="View Projection" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="760,402,125,26" Id="FIhZVIo5Mr8PX7KsqM6rdi">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -6627,12 +6608,12 @@
                         <Pin Id="CwtbJuIaz05LfNRdJwDgeM" Name="Id" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="547,530,85,19" Id="NRUhq9LHZY8OCZI8jsCqCA">
-                        <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                        <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.Rendering.Nodes">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessNode" Name="BoxMesh" />
                         </p:NodeReference>
                         <Pin Id="SvY9hVhxgEjPgHifPrAnOS" Name="Size" Kind="InputPin" DefaultValue="1, 1, 2">
-                          <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Vector3" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -6645,7 +6626,7 @@
                         <Pin Id="BkUNlPgbnPIOk1SAQX6S8p" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="468,503,133,19" Id="O43PrdG2OPkMM033lLlGQE">
-                        <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
                           <Choice Kind="ProcessNode" Name="SuppressDiagonalsShader" />
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         </p:NodeReference>
@@ -6655,7 +6636,7 @@
                         <Pin Id="SXOr62t9kjQPzOVHlLhNh5" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="468,566,165,19" Id="JVLBdRX5O0xQNCSLyVW84d">
-                        <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
                         </p:NodeReference>
@@ -6671,14 +6652,14 @@
                         <Pin Id="RlZk1H9Bqi9MqgHt3RwwNp" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="448,595,165,19" Id="PNJ9NjxMm0LPNoYK32O1t7">
-                        <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="RenderEntity" />
                         </p:NodeReference>
                         <Pin Id="EMgbmIHsLxnPmysPEQA8wq" Name="Transformation" Kind="InputPin" />
                         <Pin Id="AKrp5QViIIzNCwwZteHZlX" Name="Input" Kind="InputPin" />
                         <Pin Id="C0hdzNR5tsIMj87JHG82is" Name="Render Stage" Kind="InputPin" DefaultValue="AfterScene">
-                          <p:TypeAnnotation LastCategoryFullName="VL.Stride.Rendering" LastSymbolSource="VL.Stride.Runtime.dll">
+                          <p:TypeAnnotation LastCategoryFullName="VL.Stride.Rendering" LastDependency="VL.Stride.Runtime.dll">
                             <Choice Kind="TypeFlag" Name="DrawerRenderStage" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -6691,30 +6672,30 @@
                         <Pin Id="DNqtkznKJP6PJoBhgL4QLJ" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="548,473,46,19" Id="T9lBFQJZidwLJjpbjh9MOi">
-                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                           <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
                         </p:NodeReference>
                         <Pin Id="JbEIt3RyORKOSQfZS7flOP" Name="X" Kind="InputPin" DefaultValue="2">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="Nod8kVF4p8kNQsD4Y9GhPj" Name="Y" Kind="InputPin" DefaultValue="2">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="RAwZbaJuFEXOuUNWrqoPis" Name="Z" Kind="InputPin" DefaultValue="1.999">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="Vq2eI4TxldEPVWqUeCD7mO" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="448,468,42,19" Id="V3yvt0qtp6aLLpffEnwSu3">
-                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Invert" />
                           <CategoryReference Kind="RecordType" Name="Matrix" NeedsToBeDirectParent="true" />
@@ -6723,7 +6704,7 @@
                         <Pin Id="HswHQ8qsO1BLF4mPGzwLkW" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="706,508,133,19" Id="FqWpc8ld9MKP6RTZrsz5yA">
-                        <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
                           <Choice Kind="ProcessNode" Name="SuppressDiagonalsShader" />
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         </p:NodeReference>
@@ -6733,7 +6714,7 @@
                         <Pin Id="KQ2UQy26L9CORw8oZMSL6h" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="706,571,165,19" Id="TEOp7KtLFHNQMqgcPmyvlt">
-                        <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
                         </p:NodeReference>
@@ -6749,14 +6730,14 @@
                         <Pin Id="C8tpVpIY8IINK2E2hq5j6q" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="686,600,165,19" Id="CMbNZ1WOsKhMIhSuxdmkYm">
-                        <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="RenderEntity" />
                         </p:NodeReference>
                         <Pin Id="EzVBSKGCJZNMGO7UCVgacB" Name="Transformation" Kind="InputPin" />
                         <Pin Id="TYHiUWB4F0FOraaZgx1IRq" Name="Input" Kind="InputPin" />
                         <Pin Id="LLn7cJxHuuvO09UAwy1XAI" Name="Render Stage" Kind="InputPin" DefaultValue="AfterScene">
-                          <p:TypeAnnotation LastCategoryFullName="VL.Stride.Rendering" LastSymbolSource="VL.Stride.Runtime.dll">
+                          <p:TypeAnnotation LastCategoryFullName="VL.Stride.Rendering" LastDependency="VL.Stride.Runtime.dll">
                             <Choice Kind="TypeFlag" Name="DrawerRenderStage" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -6769,22 +6750,22 @@
                         <Pin Id="OvcWaeNNX0oPhEpgerdm3y" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="786,537,105,19" Id="MsmQNBNF7CaM6A6oc11x55">
-                        <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                        <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.Rendering.Nodes">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessNode" Name="SphereMesh" />
                         </p:NodeReference>
                         <Pin Id="GPsUts7eQfNQGULeNsBpvB" Name="Radius" Kind="InputPin" DefaultValue="0.5">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="TK87k4L03LrK96BIdMJwXb" Name="Tessellation" Kind="InputPin" DefaultValue="3">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Integer32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="J9LGWJLlMVVOlbi92mqbGm" Name="Scale" Kind="InputPin" DefaultValue="1, 1, 1">
-                          <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Vector3" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -6794,7 +6775,7 @@
                         <Pin Id="LSmSJq4rYXvQTOQLHOHq4O" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="685,465,80,19" Id="TLv5FaBCyQkMFTUmBBZL4s">
-                        <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="TransformSRT" />
                           <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -6808,7 +6789,7 @@
                         <Pin Id="FF3jaTskyFPQYO4F2BpVGb" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="408,669,105,19" Id="BFR9VKulrWLPjpuEktSGjY">
-                        <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Group" />
                           <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -6822,12 +6803,12 @@
                         <Pin Id="KtOtpvTWcawOxsTT2SMHM5" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="776,465,65,19" Id="FN3Bv1nqMNuOWvNSYHOJuZ">
-                        <p:NodeReference LastCategoryFullName="Color.RGBA" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="FromHSL" />
                         </p:NodeReference>
                         <Pin Id="SFrjWaxvtqINmRGB3pKqid" Name="Hue" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -6839,7 +6820,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="333,180,65,19" Id="L7zymWodmR1L68XJE0PS9a">
-                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                     </p:NodeReference>
@@ -6849,7 +6830,7 @@
                   </Node>
                   <ControlPoint Id="GCARgsjMz4fOJu19qtmhyu" Bounds="410,746" />
                   <Node Bounds="333,213,37,19" Id="OhKlQ3D2lGdL5xNnHofqze">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="AND" />
                     </p:NodeReference>
@@ -6859,12 +6840,12 @@
                   </Node>
                   <ControlPoint Id="CWC5Cm3y4iKMw9yyk5krPE" Bounds="890,128" />
                   <Node Bounds="713,123,63,19" Id="Q5vcN9LGhjrMFaPSi3J4Tp">
-                    <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ToVector3 (Float32)" />
                     </p:NodeReference>
                     <Pin Id="NRWbtEfvKJ2OkEUHeewZAj" Name="Value" Kind="InputPin" DefaultValue="1">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Float32" />
                       </p:TypeAnnotation>
                     </Pin>
@@ -6911,7 +6892,7 @@
                 <Patch Id="DNMc1W5FnoVPlcS804oMsm" Name="Create" />
                 <Patch Id="Q3HlPcKbP3tPKQfjQWkaJF" Name="Update">
                   <Pin Id="JRDtwJ9knTDMRF5JOI4iwq" Name="Input" Kind="InputPin">
-                    <p:TypeAnnotation LastCategoryFullName="Stride.Cameras.Animation.Models" LastSymbolSource="VL.Addons.Stride.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.Cameras.Animation.Models" LastDependency="VL.Addons.Stride.vl">
                       <Choice Kind="TypeFlag" Name="CameraModel" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -6928,18 +6909,18 @@
 
 -->
           <Node Name="Camera" Bounds="315,228" Id="JR8tOH2hFPWOwLWkx5lguT">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="ContainerDefinition" Name="Process" />
             </p:NodeReference>
             <Patch Id="BPb1wBFCEjbOYSPEHlF3Gy">
               <Canvas Id="L2iGYITBdn9L6Y4B59518m" CanvasType="Group">
                 <Node Bounds="361,512,225,19" Id="SLNOW9m9xdiQNmEAIoQn53">
-                  <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera" LastSymbolSource="VL.Addons.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera" LastDependency="VL.Addons.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="CameraProcess" />
                   </p:NodeReference>
                   <Pin Id="I7mZj2DVfoVPcITY1Es0Zn" Name="Filter Time" Kind="InputPin" DefaultValue="3">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Float32" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -6961,7 +6942,7 @@
                   <Pin Id="CPKnvTKcEfWQZFjMYBGiJL" Name="Idle" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="328,587,72,19" Id="CNpdeSWTYu3Oat7vJ1PtvV">
-                  <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera" LastSymbolSource="VL.Addons.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera" LastDependency="VL.Addons.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="CameraView" />
                   </p:NodeReference>
@@ -6973,7 +6954,7 @@
                   <Pin Id="U9doUqbT7CMLnNxZdKaDDe" Name="View Projection" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="676,452,125,19" Id="LIBHroWbF3ePYN7jjTAv0b">
-                  <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera" LastSymbolSource="VL.Addons.Stride.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera" LastDependency="VL.Addons.Stride.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="CameraControls" />
                   </p:NodeReference>
@@ -6987,7 +6968,7 @@
                   <Pin Id="QkFl02HKVx0NwpvIF9rRy0" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="327,160,158,19" Id="JLfGgbLX1cbOx30q3hKP4X">
-                  <p:NodeReference LastCategoryFullName="Stride.Input" LastSymbolSource="VL.Stride.Engine.Nodes">
+                  <p:NodeReference LastCategoryFullName="Stride.Input" LastDependency="VL.Stride.Engine.Nodes">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessNode" Name="CameraInputSourceComponent" />
                   </p:NodeReference>
@@ -6996,7 +6977,7 @@
                   <Pin Id="QJzXJ8q3ToqL70US8vNfnx" Name="Input Source" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="326,414,39,19" Id="GEHQdSpZ4CqOIUoxhKFWIw">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Cons" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -7006,7 +6987,7 @@
                 </Node>
                 <ControlPoint Id="JNYRNewaS05OaIW5SWcJcY" Bounds="907,108" />
                 <Node Bounds="715,338,45,19" Id="L0PYamEKetzPmMBY2Yma7M">
-                  <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Switch" />
                     <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
@@ -7048,7 +7029,7 @@
                     <Canvas Id="OkrNbmWahsKO5thg90ADkH" CanvasType="Group">
                       <Pad Id="R8owV4tCuvrNQILWaGZrsq" SlotId="PBSFXvtiRgfNJ0btArds4N" Bounds="527,297" />
                       <Node Bounds="524,213,95,26" Id="N21Z8iOcMUDPo5s0gppA8g">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraControlsModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraControlsModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Create" />
                           <CategoryReference Kind="RecordType" Name="CameraControlsModel" NeedsToBeDirectParent="true" />
@@ -7056,7 +7037,7 @@
                         <Pin Id="EIFHSHSrvG2O0gftjpOTaq" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="533,847,1362,26" Id="DEUBQU86fcRLl9XjaxjMD5">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraControlsModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraControlsModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Combine" />
                           <CategoryReference Kind="RecordType" Name="CameraControlsModel" NeedsToBeDirectParent="true" />
@@ -7080,7 +7061,7 @@
                       <ControlPoint Id="KKuUfdd2VwMO08eA5AKLRu" Bounds="755,327" />
                       <ControlPoint Id="U6OeY4prML8OqkC0biRtkj" Bounds="779,374" />
                       <Node Bounds="920,776,105,19" Id="VZYURnmdYttNqNalZlKbq1">
-                        <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Filter" />
                         </p:NodeReference>
@@ -7094,22 +7075,22 @@
                         <Pin Id="BXzaXWxXVr1PgpunNYqECt" Name="Progress" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="942,693,45,19" Id="PGhzoRCZA4BOCzGatb2Nby">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="*" />
                         </p:NodeReference>
                         <Pin Id="LwsuoPbDCGXLsqMXExQrUS" Name="Input" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="N3unanr186rLH2BiOvxKWA" Name="Input 2" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="Jtp9ySKPiHhMloKdrjOKMr" Name="Input 3" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -7117,7 +7098,7 @@
                       </Node>
                       <ControlPoint Id="FvsOz6t2wYXQJh8qAfiKry" Bounds="964,-83" />
                       <Node Bounds="951,-12,644,393" Id="Tq2XaQFCwNaLQeP7qhuKQ2">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <FullNameCategoryReference ID="Primitive" />
@@ -7139,7 +7120,7 @@
                           <Patch Id="UZ2MvFJxXoROVpPTk42UVx" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="QBqJiPQy45QMnvVZXPz3Mq" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="963,12,66,19" Id="ASrW0eCygUbPlaLmc8ytF8">
-                            <p:NodeReference LastCategoryFullName="Stride.Input" LastSymbolSource="VL.Stride.Input.vl" LastDependency="VL.Stride.vl">
+                            <p:NodeReference LastCategoryFullName="Stride.Input" LastDependency="VL.Stride.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="ProcessAppFlag" Name="GetDevices" />
                             </p:NodeReference>
@@ -7149,7 +7130,7 @@
                             <Pin Id="BV3oJjheOIeOAarFVmE3sT" Name="Pointer Device" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="964,93,65,26" Id="CU2zHXi1YpgO5KrzEdhDRS">
-                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="Category" Name="Stride" />
                               <CategoryReference Kind="Category" Name="Input" />
@@ -7161,7 +7142,7 @@
                             <Pin Id="CqOFDx2k8g6OfcZBfGUHcB" Name="Delta" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="963,142,79,26" Id="Ttr5LCovKx9NRm1FQXc9U4">
-                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsButtonDown" />
                             </p:NodeReference>
@@ -7171,13 +7152,13 @@
                             <Pin Id="BC1u15RUIv4QRvZgQigt0U" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="964,191,79,26" Id="Fe8vlFUWTmQLAQyZsg06et">
-                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsButtonDown" />
                             </p:NodeReference>
                             <Pin Id="LJzpNt2KUwsL1VlhmUJlmk" Name="Input" Kind="StateInputPin" />
                             <Pin Id="TbwnYCwRgEQLWSpmCDTOtZ" Name="Mouse Button" Kind="InputPin" DefaultValue="Middle">
-                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                                 <Choice Kind="TypeFlag" Name="MouseButton" />
                               </p:TypeAnnotation>
                             </Pin>
@@ -7185,13 +7166,13 @@
                             <Pin Id="GjQILWYMnroN2DcDmODZaZ" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="963,242,79,26" Id="QrA15Lxw5amMn6YdgzADCR">
-                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsButtonDown" />
                             </p:NodeReference>
                             <Pin Id="LjrkzsqwUruQI5pJsNVuRw" Name="Input" Kind="StateInputPin" />
                             <Pin Id="AhscFqiuPWFQWuoUIxwJdI" Name="Mouse Button" Kind="InputPin" DefaultValue="Right">
-                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                                 <Choice Kind="TypeFlag" Name="MouseButton" />
                               </p:TypeAnnotation>
                             </Pin>
@@ -7199,29 +7180,29 @@
                             <Pin Id="LltzgemqjgkOy8Udw8Xvoq" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Pad Id="DW3GAwemex7PRpNLd553Gv" Comment="Mouse Button" Bounds="1057,160,77,15" ShowValueBox="true" isIOBox="true" Value="Middle">
-                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                               <Choice Kind="TypeFlag" Name="MouseButton" />
                             </p:TypeAnnotation>
                           </Pad>
                           <Pad Id="LkHb4EMaybHN7i62A99jgn" Comment="Mouse Button" Bounds="1058,215,77,15" ShowValueBox="true" isIOBox="true" Value="Right">
-                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                               <Choice Kind="TypeFlag" Name="MouseButton" />
                             </p:TypeAnnotation>
                           </Pad>
                           <Pad Id="Q9DDsO7paLKNELxEUAFLbC" Comment="Mouse Button" Bounds="1056,102,77,15" ShowValueBox="true" isIOBox="true" Value="Left">
-                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                               <Choice Kind="TypeFlag" Name="MouseButton" />
                             </p:TypeAnnotation>
                           </Pad>
                           <Node Bounds="1305,98,75,26" Id="KZCimeFQhJLL9zBuXXIijG">
-                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
                               <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
                             </p:NodeReference>
                             <Pin Id="Ca4GHvRFhIGLD2ncLNTosL" Name="Input" Kind="StateInputPin" />
                             <Pin Id="PnIgiy36hUFN0K0BFWLaX6" Name="Key" Kind="InputPin" DefaultValue="R">
-                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                                 <Choice Kind="TypeFlag" Name="Keys" />
                               </p:TypeAnnotation>
                             </Pin>
@@ -7229,19 +7210,19 @@
                             <Pin Id="Vnty7s9uFKiQGAntDinFuX" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Pad Id="BbXJCdEiG0NLDZnqyFDaVo" Comment="Key" Bounds="1376,60,119,15" ShowValueBox="true" isIOBox="true" Value="R">
-                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                               <Choice Kind="TypeFlag" Name="Keys" />
                             </p:TypeAnnotation>
                           </Pad>
                           <Node Bounds="1306,193,75,26" Id="VM1dhmDq8i5OhWEQc5DT7A">
-                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
                               <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
                             </p:NodeReference>
                             <Pin Id="CHOtLMG0rlhML4atlGOtYU" Name="Input" Kind="StateInputPin" />
                             <Pin Id="RVijoa6qd2qOI3TbIrSi5f" Name="Key" Kind="InputPin" DefaultValue="LeftCtrl">
-                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                                 <Choice Kind="TypeFlag" Name="Keys" />
                               </p:TypeAnnotation>
                             </Pin>
@@ -7249,19 +7230,19 @@
                             <Pin Id="TTFKg0eM5BmPcNr5x7RatE" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Pad Id="QGo3higbe6jNGht7nIG7lB" Comment="Key" Bounds="1379,148,119,15" ShowValueBox="true" isIOBox="true" Value="LeftCtrl">
-                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                               <Choice Kind="TypeFlag" Name="Keys" />
                             </p:TypeAnnotation>
                           </Pad>
                           <Node Bounds="1306,243,75,26" Id="OMNDtaoV6QiMIVwmGu9D3j">
-                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                            <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
                               <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
                             </p:NodeReference>
                             <Pin Id="E6JtRR6Yo2TNSzvEGPqZSI" Name="Input" Kind="StateInputPin" />
                             <Pin Id="DxQslppHj2qOrK63I9hyUI" Name="Key" Kind="InputPin" DefaultValue="LeftCtrl">
-                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                              <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                                 <Choice Kind="TypeFlag" Name="Keys" />
                               </p:TypeAnnotation>
                             </Pin>
@@ -7269,12 +7250,12 @@
                             <Pin Id="KNmhMtzXjaePdXXXFHigSQ" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Pad Id="AZqvses32bkLbh3sIAxlOV" Comment="Key" Bounds="1419,190,119,15" ShowValueBox="true" isIOBox="true" Value="RightCtrl">
-                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastSymbolSource="Stride.Input.dll">
+                            <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                               <Choice Kind="TypeFlag" Name="Keys" />
                             </p:TypeAnnotation>
                           </Pad>
                           <Node Bounds="1358,291,30,19" Id="L7EFTiEKa5gPLCITcbDrmp">
-                            <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="OR" />
                             </p:NodeReference>
@@ -7285,7 +7266,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="951,-54,65,19" Id="Ug8n33BLkn1MDcaoQrHqcD">
-                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                         </p:NodeReference>
@@ -7294,7 +7275,7 @@
                         <Pin Id="LnegiID7FBaPHOWIh4AGEI" Name="Not Assigned" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1115,776,105,19" Id="KNizDUZi0FBNADyrc3HjmH">
-                        <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Filter" />
                         </p:NodeReference>
@@ -7308,29 +7289,29 @@
                         <Pin Id="ImN9sM2GHIKO5wZIThAVDb" Name="Progress" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1137,693,45,19" Id="NLjKTpEVL5bLxxpSYQrzg5">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="*" />
                         </p:NodeReference>
                         <Pin Id="ON2A6ooW8dBLmYwtNapcoo" Name="Input" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="VG3YEz9HNkpPWfR0KbZl20" Name="Input 2" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="S9Gc23FJZuaNxAFS8IUHtz" Name="Input 3" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="QfDjqHOpxscM59YI9t3f6O" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1500,776,105,19" Id="KD8GTI3OyoMLavOXduijBo">
-                        <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Filter" />
                         </p:NodeReference>
@@ -7344,29 +7325,29 @@
                         <Pin Id="Ehd2BOhUrjyNhvKOEtHeZR" Name="Progress" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1522,693,45,19" Id="NzoYBvmzlKlOJegd4TVtRb">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="*" />
                         </p:NodeReference>
                         <Pin Id="NT9mSTJRjGYNNACBAd08wS" Name="Input" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="C9NNHHoNlyZPN8nn1xkV8R" Name="Input 2" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="SgTbkfb2ACxPK3ECc5Xii0" Name="Input 3" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="AGqWI5p2zPYLb0HvDUVAtE" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="726,776,105,19" Id="PMUtYiWJDgnQMUqMsV5Uue">
-                        <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Filter" />
                         </p:NodeReference>
@@ -7380,7 +7361,7 @@
                         <Pin Id="JFQjRjBjM84ONZRppkHzet" Name="Progress" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1309,776,105,19" Id="UsZSNMElMmIOoJe534MeB9">
-                        <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Filter" />
                         </p:NodeReference>
@@ -7394,7 +7375,7 @@
                         <Pin Id="IbNFMuupOkBPQrns8lcwCP" Name="Progress" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1331,693,45,19" Id="AB5aXUsDGRoPAfY2x3M60y">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="*" />
                         </p:NodeReference>
@@ -7404,7 +7385,7 @@
                         <Pin Id="Pd8RaPpCQWMP2EWQNHsSZB" Name="Input 3" Kind="InputPin" />
                       </Node>
                       <Node Bounds="744,693,65,19" Id="Foqrl4e0WxKMZjQVoiNSsR">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                         </p:NodeReference>
@@ -7420,7 +7401,7 @@
 
 -->
                       <Node Name="Vector2FlipX (Internal)" Bounds="506,372,124,239" Id="DXPo4NHe9F3NnndALXYEKB">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                           <Choice Kind="OperationDefinition" Name="Operation" />
                         </p:NodeReference>
                         <Patch Id="PcKI0FxHtJsO5qGKCnwAqb">
@@ -7428,7 +7409,7 @@
                           <ControlPoint Id="P23wdqrqtAsNyUMMcvJmhf" Bounds="552,390" />
                           <Link Id="LAI9q9OwbM0QQ0LgdKt90E" Ids="KgVr42grSrpNLEmfU5ZMUS,P23wdqrqtAsNyUMMcvJmhf" IsHidden="true" />
                           <Node Bounds="518,463,44,26" Id="EtvH9JZ3dJvP4HJt6Ieb6w">
-                            <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="X" />
                               <CategoryReference Kind="Vector2Type" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -7438,7 +7419,7 @@
                           </Node>
                           <Link Id="DDuDmVMvl56PXJ4NHvsH7A" Ids="P23wdqrqtAsNyUMMcvJmhf,UgehM2DKP3hMQATe11W7EC" />
                           <Node Bounds="574,463,44,26" Id="HdtaBJ7khdRNJyktxknoO6">
-                            <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Y" />
                               <CategoryReference Kind="Vector2Type" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -7448,7 +7429,7 @@
                           </Node>
                           <Link Id="NfZTL8hE1gIOk119rNfo7d" Ids="P23wdqrqtAsNyUMMcvJmhf,CutORhIlpZlPXp9LpT1abr" />
                           <Node Bounds="518,501,22,19" Id="HWMcK0SeFQrNmDliht52DZ">
-                            <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="- (Negate)" />
                             </p:NodeReference>
@@ -7457,7 +7438,7 @@
                           </Node>
                           <Link Id="OB8a1I9ClsHQS9dEQmROfC" Ids="C2J7TkeLAAFNqMkWSZAbVB,B96oi4hhTWiN11mQchKGfK" />
                           <Node Bounds="534,537,46,19" Id="HNKuAgjMiH9PbyiSJ64EJh">
-                            <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                               <CategoryReference Kind="Vector2Type" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -7475,7 +7456,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="941,506,74,19" Id="NfDbmQo1cENPnd3Zg1x1LS">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera.CameraControls" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera.CameraControls" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Vector2FlipX" />
                         </p:NodeReference>
@@ -7483,7 +7464,7 @@
                         <Pin Id="IPRaSJCWk5ULU2nWFISkzj" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="941,563,46,19" Id="DlV8rbi6yLsM7NLnvzHMLb">
-                        <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Vector (Split)" />
                           <CategoryReference Kind="Vector2Type" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -7493,7 +7474,7 @@
                         <Pin Id="AQ3iWVDsxkeQENbgDokMr3" Name="Y" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1561,589,37,19" Id="BHE4b3W6ryXPoFEpv3d0cq">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                         </p:NodeReference>
@@ -7502,7 +7483,7 @@
                         <Pin Id="MTCvkZ8LAWpPUcI75EMoPR" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="1372,593,57,19" Id="LDy9Tp0CariMJ3nGVang5u">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ANDNOT" />
                         </p:NodeReference>
@@ -7511,7 +7492,7 @@
                         <Pin Id="QjRbG4lE82PNV6I5RawWd2" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="1888,697,85,19" Id="EG0OuJ806swOaCzMtupCn1">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="OR" />
                         </p:NodeReference>
@@ -7523,7 +7504,7 @@
                         <Pin Id="N9ptHzvunqnPw4J73YhauP" Name="Input 5" Kind="InputPin" />
                       </Node>
                       <Node Bounds="1888,765,37,19" Id="ONXRnztFnAeOiGLROjxeiG">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="NOT" />
                         </p:NodeReference>
@@ -7531,14 +7512,14 @@
                         <Pin Id="BVEJOQaAqcxNaEHi8JiPAI" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="1695,677,62,19" Id="EUlH4CHy4JdOr6hFegFNj5">
-                        <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="TimerFlop" />
                         </p:NodeReference>
                         <Pin Id="ALLg2O4jYkPLN7UCaKEVVW" Name="Set" Kind="InputPin" />
                         <Pin Id="BReRa8lywqeOxmNyZeh8kH" Name="Reset" Kind="InputPin" />
                         <Pin Id="Ejn9CjWhREQMk27E90nUIk" Name="Time" Kind="InputPin" DefaultValue="0.5">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -7546,7 +7527,7 @@
                         <Pin Id="O7o86z8Uj7zOW87QujcIJF" Name="Running" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1696,723,56,19" Id="OkbeXI7USmAMQeGqdJpnp2">
-                        <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="TogEdge" />
                         </p:NodeReference>
@@ -7555,7 +7536,7 @@
                         <Pin Id="Pi0Lt6Re7f1QbPKeYPpFCc" Name="Down Edge" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="743,635,22,19" Id="QaZmDy3gdgrK9fkupPtOrH">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="- (Negate)" />
                         </p:NodeReference>
@@ -7666,37 +7647,37 @@
                     <Patch Id="T8RdpFyDFY8O9OQSkxkbBW" Name="Create" ParticipatingElements="N21Z8iOcMUDPo5s0gppA8g" />
                     <Patch Id="QMLIugeeKbjQOUokuXbDHY" Name="Update">
                       <Pin Id="DnpFbbyPYJ5LJ3kITohh15" Name="Interest Delta Speed" Kind="InputPin" DefaultValue="1">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="HMTjR0nREEfO3VAwE6n1J1" Name="Pan Enabled" Kind="InputPin" Bounds="845,125" DefaultValue="True">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Boolean" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="AOyyPt3cTeGLAGcVvLlRB7" Name="Window Input Source" Kind="InputPin" Bounds="1070,90">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.vl">
                           <Choice Kind="TypeFlag" Name="IInputSource" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="RKYCiIYsBGuP2isWLNjmLY" Name="Longitude / Latitude Delta Speed" Kind="InputPin" Bounds="476,76" DefaultValue="1">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="PXSb7GxoGYLLDjQGZqfA3O" Name="Distance Delta Speed" Kind="InputPin" DefaultValue="20">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="TGmijSbBV0sOhsCjBBSMR7" Name="FOV Delta Speed" Kind="InputPin" DefaultValue="0.2">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="DrhFSRkbjSXLPBHIONjxSX" Name="Filter Time" Kind="InputPin" Bounds="596,485" DefaultValue="0.3">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
@@ -7710,13 +7691,13 @@
 
 -->
                 <Node Name="CameraProcess" Bounds="-210,163" Id="KuhT7oWAllbMtWyJrSJl6l">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                     <Choice Kind="ContainerDefinition" Name="Process" />
                   </p:NodeReference>
                   <Patch Id="DbWqq1aCu6NPGtVy9nXtA8">
                     <Canvas Id="UtBXyc0fy8yLqtRXoT5CTL" CanvasType="Group">
                       <Node Bounds="130,474,551,26" Id="NU9FjVQGw6KQRi97XPH7HR">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -7733,7 +7714,7 @@
                         <Pin Id="IowOSy1Uq4dLN24wmGhCmN" Name="Id" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="-73,-90,65,26" Id="NyDZLtTyY4eOpGs1P1BTE5">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Create" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -7749,7 +7730,7 @@
                       <ControlPoint Id="FBzsurj9M0XNiFJoRv49Lq" Bounds="239,177" />
                       <ControlPoint Id="HT1HXiRTRW3NAdBuDhxNj1" Bounds="263,211" />
                       <Node Bounds="103,296,185,26" Id="Er7EJStC6XNNqh3RNCPg4e">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Join" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -7760,21 +7741,21 @@
                         <Pin Id="Ha6GNHxYTaHMOj8hDJG3TR" Name="Latitude" Kind="InputPin" />
                         <Pin Id="Ow7usMRcxT6PZJ1zCnUfN4" Name="Distance" Kind="InputPin" />
                         <Pin Id="EhST5r6NnhYOaBBIa7YOOe" Name="FOV" Kind="InputPin" DefaultValue="0">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="Bi9Qzo216UWMNMCfOHGf7b" Name="Far Plane" Kind="InputPin" />
                         <Pin Id="KoL87ttrO3oNDxE6prccRc" Name="Near Plane" Kind="InputPin" />
                         <Pin Id="ET3lOfIW6OKNj0Fpq0iCDX" Name="Apply" Kind="InputPin" DefaultValue="False">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Boolean" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="HVIpSnK6DV3P0jUqtXH1Hc" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="347,207,54,19" Id="MxjJImPGO4APeLj0daIr4Q">
-                        <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="OnOpen" />
                         </p:NodeReference>
@@ -7782,7 +7763,7 @@
                         <Pin Id="IvWvOd70ryRMHh5RCSoGF2" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="327,254,65,19" Id="C5jQwtw5uQfMiay2pJsshh">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="OR" />
                         </p:NodeReference>
@@ -7796,7 +7777,7 @@
                       <Pad Id="PJcHAaMoOFXPpq7xl5blls" SlotId="SJuM9NPPSUQQJxBiyT6mQ8" Bounds="105,238" />
                       <ControlPoint Id="TOdoiWP9j1ePnpsei8MRSX" Bounds="590,144" />
                       <Node Bounds="588,202,374,26" Id="TaBCXfhF00dLhOTcvxFmcl">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraControlsModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraControlsModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
                           <CategoryReference Kind="RecordType" Name="CameraControlsModel" NeedsToBeDirectParent="true" />
@@ -7811,7 +7792,7 @@
                         <Pin Id="D0Tz5XR18hWLFKlDJJpqn8" Name="Idle" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="182,224,22,19" Id="L2q7NXE6KHeLqPoIyPahiD">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="- (Negate)" />
                         </p:NodeReference>
@@ -7819,7 +7800,7 @@
                         <Pin Id="RQJtF4qFmayOZaL4cLNgTl" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="104,1034,597,26" Id="VxLo6b5NC5rNXU2otq7Uhi">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" />
                           <Choice Kind="OperationCallFlag" Name="Join" />
@@ -7836,7 +7817,7 @@
                       </Node>
                       <Pad Id="RcGf3rVYzAEOnUoM9MlfTQ" SlotId="SJuM9NPPSUQQJxBiyT6mQ8" Bounds="106,1093" />
                       <Node Bounds="408,682,25,19" Id="CAg6etgXLMLPdqNIcCv4Rj">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="+" />
                         </p:NodeReference>
@@ -7845,25 +7826,25 @@
                         <Pin Id="FaGFtsdzY3gO99iXPYD8Ke" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="408,732,45,19" Id="GTlmvHj3RwPN8Tiis8OrmC">
-                        <p:NodeReference LastCategoryFullName="Math.Ranges" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Clamp" />
                         </p:NodeReference>
                         <Pin Id="Fdojf7DsnxjM6kY8NxGZbG" Name="Input" Kind="InputPin" />
                         <Pin Id="ID1Dt3YR6jSOEOG74cGIhn" Name="Minimum" Kind="InputPin" DefaultValue="-0.2499">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="N1v0aU3bCG5MGcbE3ifqbi" Name="Maximum" Kind="InputPin" DefaultValue="0.2499">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="CQcYNpoupvXPtrLsF4ZaTC" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="225,673,63,19" Id="PR2paVpIlMjP6JjSqJEzX1">
-                        <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ToVector3" />
                           <CategoryReference Kind="Vector2Type" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -7873,7 +7854,7 @@
                         <Pin Id="LVDEptebZ2nOX7DMlcTHjN" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="428,640,22,19" Id="Th2bcFijlLaQTs3NkSXQAa">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="- (Negate)" />
                         </p:NodeReference>
@@ -7881,12 +7862,12 @@
                         <Pin Id="BtO005UeiOnOhEuNNksUsC" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="225,638,25,19" Id="J5KrgJE9vYIQYnoTh4uEE6">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="*" />
                         </p:NodeReference>
                         <Pin Id="As7ultEGsH7QZlOZZ3uCGg" Name="Input" Kind="InputPin" DefaultValue="-1, 1">
-                          <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Vector2" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -7894,7 +7875,7 @@
                         <Pin Id="SPBFNZ9YZVkOC60WEJfmZT" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="324,769,46,19" Id="JwjDYS4dDSHPEzb1R87SQi">
-                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="OperationNode" Name="Vector (Join)" />
                           <CategoryReference Kind="Category" Name="Vector3" />
                         </p:NodeReference>
@@ -7904,7 +7885,7 @@
                         <Pin Id="RB5QTErYyVzOAqpcGszNxN" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="284,811,45,19" Id="EUE3HxZ8r45MYBETzfrsCw">
-                        <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Rotate" />
                           <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -7916,7 +7897,7 @@
                         <Pin Id="OfU0RPQ5Cr9M6krl1HWWCO" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="154,918,25,19" Id="HHlJsZ1oNTGO8kn9iIj4h5">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="+" />
                         </p:NodeReference>
@@ -7925,7 +7906,7 @@
                         <Pin Id="O7FgBrlg8RHLSLo0yXFJGQ" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="225,711,25,19" Id="AcrBOTY3arIOuny2p6Ck1J">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="* (Scale)" />
                         </p:NodeReference>
@@ -7934,7 +7915,7 @@
                         <Pin Id="JDXrZjDKD5wQKUeba1CnQq" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="174,882,64,19" Id="SX30U8tEnrOLZ5y5eeLxv9">
-                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Transform" />
                           <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -7944,7 +7925,7 @@
                         <Pin Id="A7peMuy2a2aOvH0RzQbRyg" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Pad Id="HnZURKbN9laL8Kaaf3hbuy" Comment="Reset" Bounds="366,161,35,35" ShowValueBox="true" isIOBox="true" Value="False">
-                        <p:TypeAnnotation>
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Boolean" />
                           <FullNameCategoryReference ID="Primitive" />
                         </p:TypeAnnotation>
@@ -7953,7 +7934,7 @@
                         </p:ValueBoxSettings>
                       </Pad>
                       <Node Bounds="315,649,25,19" Id="LkGJefJbi5hPCQeJXhHvhG">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="+" />
                         </p:NodeReference>
@@ -7962,7 +7943,7 @@
                         <Pin Id="JeUl5N6z2RmP0wvXPF1MjW" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="315,690,35,19" Id="D8oAwlhHrODMe0H5btMgmT">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Frac" />
                         </p:NodeReference>
@@ -7971,7 +7952,7 @@
                         <Pin Id="AQ8SsorO2ZdOjaez6zAqkB" Name="Fractional Part" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="500,679,25,19" Id="FPUFaZcIYOmQLFzvEvBKkS">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="+" />
                         </p:NodeReference>
@@ -7980,7 +7961,7 @@
                         <Pin Id="Ng4dcCMl08RMdye17UTGeR" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="577,676,25,19" Id="Oulpghskg0vPor5gpr1QF0">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="+" />
                         </p:NodeReference>
@@ -7992,7 +7973,7 @@
                       <ControlPoint Id="TSpdYFqYtkcPtBhLDxZQSg" Bounds="697,629" />
                       <ControlPoint Id="Dgai5Pmr6UhOK1GmPmF052" Bounds="624,663" />
                       <Node Bounds="162,195,22,19" Id="TZXvQXk1xBUPY2D1G1lIJi">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="- (Negate)" />
                         </p:NodeReference>
@@ -8002,14 +7983,14 @@
                       <ControlPoint Id="VJy5kQHKoAFL9SHr4peUpo" Bounds="1028,1035" />
                       <Pad Id="BTBZFIsDrh3N9mGDzk12hQ" SlotId="SJuM9NPPSUQQJxBiyT6mQ8" Bounds="1198,402" />
                       <Node Bounds="1196,465,36,19" Id="AAQeumlV4hGPQ5RIph1Zf8">
-                        <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="S+H" />
                           <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
                         </p:NodeReference>
                         <Pin Id="Nmzh6QlIi0XOME1AuGOgEZ" Name="Value" Kind="InputPin" />
                         <Pin Id="R9pbMakjkqfLamY3VX8h46" Name="Sample" Kind="InputPin" DefaultValue="True">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Boolean" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -8018,7 +7999,7 @@
                       <ControlPoint Id="M6j4HcELXLYP46R9TIy4tw" Bounds="1731,49" />
                       <ControlPoint Id="OghEBNUZuGIQCDLMnPkf1s" Bounds="1846,147" />
                       <Node Bounds="1021,203,137,19" Id="O6HHZUxj4NGQAHQOpee8wG">
-                        <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="MonoFlop" />
                         </p:NodeReference>
@@ -8030,7 +8011,7 @@
                         <Pin Id="Ixj329SFEL5QRT8jFtMqTf" Name="Inverse Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1001,329,105,19" Id="VShiemHDRUOOMKMs4pbnrB">
-                        <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Filter" />
                         </p:NodeReference>
@@ -8038,12 +8019,12 @@
                         <Pin Id="Gn1q3nPthzJQOYjDr6Cfvj" Name="Goto Position" Kind="InputPin" />
                         <Pin Id="PW9yAQbaLNcNTXQFzZ14W8" Name="Filter Time" Kind="InputPin" />
                         <Pin Id="TQZegh5J5d7LWQD2G0p7if" Name="Transition" Kind="InputPin" DefaultValue="Expo">
-                          <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="TweenerTransition" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="QswnlJYdlKVOCwbUmlaIMl" Name="Mode" Kind="InputPin" DefaultValue="Out">
-                          <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="TweenerMode" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -8053,7 +8034,7 @@
                       </Node>
                       <ControlPoint Id="RAVZaLfigRkMTerG1AYXNe" Bounds="1042,132" />
                       <Node Bounds="1021,241,62,19" Id="SaMf83yN4Q3QN7FZWYLmwu">
-                        <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ToFloat32" />
                         </p:NodeReference>
@@ -8061,7 +8042,7 @@
                         <Pin Id="HUpLMxmgA39MSlkGBmSMiZ" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1196,514,165,26" Id="SsQxGGp5Ht8NXrxB9RM1Ah">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -8078,7 +8059,7 @@
                         <Pin Id="KBVeDTtZO4VQMXLdG7TlMG" Name="Id" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1196,587,45,19" Id="QfNDlsa1VsaNNPVuF48bb2">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Lerp" />
                         </p:NodeReference>
@@ -8088,7 +8069,7 @@
                         <Pin Id="Vpq8OIZzhqaLzppmnrzAIv" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1226,617,45,19" Id="N5iJNQqEfbHLU1yzU1K5M4">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Lerp" />
                         </p:NodeReference>
@@ -8098,7 +8079,7 @@
                         <Pin Id="VE70hdFoOquMG3kyFzkleb" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1256,647,45,19" Id="G2I9DdFqzggMy12SHgXY21">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Lerp" />
                         </p:NodeReference>
@@ -8108,7 +8089,7 @@
                         <Pin Id="Lbm4GPkYNgsOTjA8uRISZQ" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1286,677,45,19" Id="KVR5PRmBi2uNscvTPJk3nb">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Lerp" />
                         </p:NodeReference>
@@ -8118,7 +8099,7 @@
                         <Pin Id="RWmvIHZRaFJM6O0SeSleQi" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1316,707,45,19" Id="MxGMc15rqc8PdblZkFcfGh">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Lerp" />
                         </p:NodeReference>
@@ -8128,7 +8109,7 @@
                         <Pin Id="QbhynoXyATRPEaqXmPWidn" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1346,737,45,19" Id="Sl73llUyAOSOdqONunvlQS">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Lerp" />
                         </p:NodeReference>
@@ -8138,7 +8119,7 @@
                         <Pin Id="MUqkR8B0S06MGyMEDcBnJJ" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1376,767,45,19" Id="DdRqYrZNJq3MlTUmMUBUhx">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Lerp" />
                         </p:NodeReference>
@@ -8148,7 +8129,7 @@
                         <Pin Id="MeCOLJ87yg8NTO3gIQ5a4Z" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1178,939,165,26" Id="UPozK8dGG10MedW1WDijoR">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Join" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -8172,7 +8153,7 @@
                       <ControlPoint Id="SL1xNQKTg1pMhOKdYcrxFi" Bounds="878,1035" />
                       <ControlPoint Id="DqHssUELoJPOg1OJYXqgIx" Bounds="948,1035" />
                       <Node Bounds="1178,1000,201,26" Id="Pf79VluaWTsLepz5QbkbmJ">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="SetId" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -8183,7 +8164,7 @@
                         <Pin Id="Ko8Dl9YVGqTNvIH3qBbXPe" Name="Apply" Kind="InputPin" />
                       </Node>
                       <Node Bounds="1701,825,56,19" Id="D66AsQUXD4nNId6TxGespx">
-                        <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="TogEdge" />
                         </p:NodeReference>
@@ -8192,7 +8173,7 @@
                         <Pin Id="U0j3NsdSfBVOTlkyyLpN8b" Name="Down Edge" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="103,413,201,26" Id="NFRffHi3t48PtFPiQSbYAk">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="SetId" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -8204,7 +8185,7 @@
                       </Node>
                       <ControlPoint Id="PjbHJcTDdnKPfRw5V0sBE2" Bounds="301,335" />
                       <Node Bounds="299,357,57,19" Id="J4MrXi8YqfjMUJuP5DFA1Z">
-                        <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Changed" />
                         </p:NodeReference>
@@ -8213,7 +8194,7 @@
                         <Pin Id="SicV3vL5magMbP4j28iA9M" Name="Unchanged" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="299,384,30,19" Id="Q4EXzIQb6pMQWc3g0PKGJm">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="OR" />
                         </p:NodeReference>
@@ -8224,7 +8205,7 @@
                       <Pad Id="Oqv4Qj7JzGEMgA9pLzERrL" SlotId="LeIRaMfBql7OLqibUuy9tv" Bounds="1486,784" />
                       <Pad Id="Ds4kKZPWdZmNCEUHBJFtsL" SlotId="LeIRaMfBql7OLqibUuy9tv" Bounds="879,964" />
                       <Node Bounds="1732,430,67,26" Id="G6lAVXLdGU1Mv6Nh3MmhEy">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="SplitSpread" />
                         </p:NodeReference>
@@ -8232,7 +8213,7 @@
                         <Pin Id="RzK1fiJOzqoMYrt4zC2TxU" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1595,430,65,26" Id="TGosnIDaifeQDwjt9O7bux">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Interest" />
                         </p:NodeReference>
@@ -8240,7 +8221,7 @@
                         <Pin Id="VETsrc3T7Z6OiBakrUyXvx" Name="Interest" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1575,501,105,19" Id="O8H5xnW2JndLV4yNZxeIXl">
-                        <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Filter" />
                         </p:NodeReference>
@@ -8248,12 +8229,12 @@
                         <Pin Id="CLAXQzsjGSNLDWUmrl0SfQ" Name="Goto Position" Kind="InputPin" />
                         <Pin Id="JgbFcrQcGMOOlcwPNMb0fg" Name="Filter Time" Kind="InputPin" />
                         <Pin Id="Dhoz7GNfsA4QGyQWJMLZmm" Name="Transition" Kind="InputPin" DefaultValue="Expo">
-                          <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="TweenerTransition" />
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="GbDNMnvNLUiN7Ss6ykSx2c" Name="Mode" Kind="InputPin" DefaultValue="Out">
-                          <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="TweenerMode" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -8262,7 +8243,7 @@
                         <Pin Id="HQv4QFxOtfWOJANJzeQRIp" Name="Progress" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1700,480,129,65" Id="IPHeyXBEQGBPoncX3qCBdD">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                           <CategoryReference Kind="Category" Name="Primitive" />
@@ -8275,7 +8256,7 @@
                           <Patch Id="KSfvTfC1Y6KQDWr4XIApU1" Name="Update" ManuallySortedPins="true" />
                           <Patch Id="ERp10CVT6eqPRPXX8M6Ktz" Name="Dispose" ManuallySortedPins="true" />
                           <Node Bounds="1712,504,105,19" Id="IRoUaiUZSBDOe1MCdkScx9">
-                            <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="ProcessAppFlag" Name="Filter" />
                             </p:NodeReference>
@@ -8283,12 +8264,12 @@
                             <Pin Id="F7mS21Wq178MJE1trvgV8W" Name="Goto Position" Kind="InputPin" />
                             <Pin Id="LLYPxNSxUqYN80Jn0g8TUA" Name="Filter Time" Kind="InputPin" />
                             <Pin Id="IBbUfexIf1sPK5pizjqEo1" Name="Transition" Kind="InputPin" DefaultValue="Expo">
-                              <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                              <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="TypeFlag" Name="TweenerTransition" />
                               </p:TypeAnnotation>
                             </Pin>
                             <Pin Id="T6FXuLsDjzbM3LxYQEU3I7" Name="Mode" Kind="InputPin" DefaultValue="Out">
-                              <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                              <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="TypeFlag" Name="TweenerMode" />
                               </p:TypeAnnotation>
                             </Pin>
@@ -8299,7 +8280,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="1712,555,105,19" Id="AgbxhBk18ZUNgODfwulOx1">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera.CameraProcess" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Camera.CameraProcess" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Decons" />
                           <CategoryReference Kind="Category" Name="CameraProcess" NeedsToBeDirectParent="true" />
@@ -8313,7 +8294,7 @@
                         <Pin Id="OfOWSgw1TpyQOtjlSsJAEi" Name="Result 6" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1812,402,69,19" Id="IHZkAq1foGVLckZ4gJNA55">
-                        <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FrameDelay" />
                         </p:NodeReference>
@@ -8321,7 +8302,7 @@
                         <Pin Id="GcOy8ekiLG7NQkMgO1XhWr" Name="Value" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="1812,434,37,19" Id="EGLc9a5g9LgOVwbxQ5EXYh">
-                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AND" />
                         </p:NodeReference>
@@ -8330,7 +8311,7 @@
                         <Pin Id="Gu9nKeTZMvLOT176zyC7ET" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="1909,432,65,26" Id="GS0RdEcD7nBLot50n5jAiY">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Id" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -8346,12 +8327,12 @@
 
 -->
                       <Node Name="Decons (Internal)" Bounds="1919,587,227,315" Id="CD0UK07AlUuMkQLBImKFpN">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                           <Choice Kind="OperationDefinition" Name="Operation" />
                         </p:NodeReference>
                         <Patch Id="IEBFp9OPnhoO9cRTBgneTn">
                           <Node Bounds="1932,678,52,19" Id="C9ukEQwFq49PCLFSTiknlJ">
-                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetSlice" />
                               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -8362,7 +8343,7 @@
                             <Pin Id="PV5sF63Ut0rLMVk3CmVghL" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1962,708,52,19" Id="OH3O685eFKjNVmJannLt9P">
-                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetSlice" />
                               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -8370,14 +8351,14 @@
                             <Pin Id="F7Zm13xHM1DOApxdXZZb6J" Name="Input" Kind="StateInputPin" />
                             <Pin Id="M9yx6Q8SYbpNxkHOsCc5cj" Name="Default Value" Kind="InputPin" />
                             <Pin Id="JYL1FwNJOsjOTRXZYzxqnq" Name="Index" Kind="InputPin" DefaultValue="1">
-                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="TypeFlag" Name="Integer32" />
                               </p:TypeAnnotation>
                             </Pin>
                             <Pin Id="OJsUmGHpcQQMxOVPRhHHnT" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1992,738,52,19" Id="HlqCyO3PDGJNsnq03e0P7Z">
-                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetSlice" />
                               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -8385,14 +8366,14 @@
                             <Pin Id="RsSJbEdRvSlPzu3IQAw6L6" Name="Input" Kind="StateInputPin" />
                             <Pin Id="C8utZZfVNRKNQCJTrKnztX" Name="Default Value" Kind="InputPin" />
                             <Pin Id="EYqfMUdnZiVNzs1lUVKKY3" Name="Index" Kind="InputPin" DefaultValue="2">
-                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="TypeFlag" Name="Integer32" />
                               </p:TypeAnnotation>
                             </Pin>
                             <Pin Id="TKL6WkG4VV8PeX5kmfphdY" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="2022,768,52,19" Id="RmJd1wQgzDJNyde7AlmP7V">
-                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetSlice" />
                               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -8400,14 +8381,14 @@
                             <Pin Id="I0fyGkjVMfTMxI4TAkZS3y" Name="Input" Kind="StateInputPin" />
                             <Pin Id="HOrZjAVOxOHNTVqUU0NOI8" Name="Default Value" Kind="InputPin" />
                             <Pin Id="IXgX2yLdrU8MwLyljR0wAC" Name="Index" Kind="InputPin" DefaultValue="3">
-                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="TypeFlag" Name="Integer32" />
                               </p:TypeAnnotation>
                             </Pin>
                             <Pin Id="EdX4xfVYsfkL05u5I3HpID" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="2052,798,52,19" Id="DpwUEImc6QGLipsYT47vs0">
-                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetSlice" />
                               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -8415,14 +8396,14 @@
                             <Pin Id="UxM0ZSV25b7MSkMpfB3SJ6" Name="Input" Kind="StateInputPin" />
                             <Pin Id="QqPi0bt1os8OYhBTvLmKFK" Name="Default Value" Kind="InputPin" />
                             <Pin Id="IOKtY0FYaaKOwzd5HdNsxA" Name="Index" Kind="InputPin" DefaultValue="4">
-                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="TypeFlag" Name="Integer32" />
                               </p:TypeAnnotation>
                             </Pin>
                             <Pin Id="EkVR6jOO5WBPES61XlgGUM" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="2082,828,52,19" Id="FBtVKNDGsVjMfcFF1sRWoJ">
-                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetSlice" />
                               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -8430,7 +8411,7 @@
                             <Pin Id="J5DlW6dBWWNLd6S49V6A4L" Name="Input" Kind="StateInputPin" />
                             <Pin Id="FOyJ95RDEGvPZ7yCgdDA0E" Name="Default Value" Kind="InputPin" />
                             <Pin Id="VeJItdslvmmN99GK9Ktwq8" Name="Index" Kind="InputPin" DefaultValue="5">
-                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="TypeFlag" Name="Integer32" />
                               </p:TypeAnnotation>
                             </Pin>
@@ -8463,7 +8444,7 @@
                           <Link Id="HGM01vQATCcNXVpSOUctt6" Ids="QMV1bHGikhQPwpKkhI5FOm,UxM0ZSV25b7MSkMpfB3SJ6" />
                           <Link Id="LaOLFxBWpCuMAKntDL1HuD" Ids="QMV1bHGikhQPwpKkhI5FOm,J5DlW6dBWWNLd6S49V6A4L" />
                           <Pin Id="D6WNXpqrtdlNvMD3jZIjVs" Name="Input" Kind="InputPin" Bounds="2100,565">
-                            <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl" LastDependency="VL.CoreLib.vl">
+                            <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="Spread" />
                               <p:TypeArguments>
                                 <TypeReference>
@@ -8634,34 +8615,34 @@
                       <Pin Id="PIctcgA4XhmNl8v7EsAvkS" Name="Initial Interest" Kind="InputPin" />
                       <Pin Id="PJatfMSnx1AOBduKL1jgXJ" Name="Initial Longitude" Kind="InputPin" />
                       <Pin Id="O1QWWpl3tOyL4G7b7WJnUS" Name="Initial Latitude" Kind="InputPin" DefaultValue="0.08">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="KDi3hr74lSKP8vtOOjQaxi" Name="Intital Distance" Kind="InputPin" DefaultValue="5">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="PnpucNf0lQdPAhEsgCeLjp" Name="Initial FOV" Kind="InputPin" DefaultValue="0.14">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="GYyt2M64256Lp2PhFD2jxk" Name="Far Plane" Kind="InputPin" DefaultValue="0.05">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="JuiLXVZ3BPvMr9iJnOisg5" Name="Near Plane" Kind="InputPin" DefaultValue="100">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Float32" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="TQJnDaw90J5PgPpn3xw56y" Name="Id" Kind="InputPin" Bounds="229,599" />
                       <Pin Id="HRHodDD4s27LzoA6F0iXBG" Name="Reset" Kind="InputPin" Bounds="24,109" />
                       <Pin Id="Ef8hjPpk5naPVEiGlGwJlG" Name="Controls Model" Kind="InputPin">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Cameras.Animation.Models" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Cameras.Animation.Models" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="TypeFlag" Name="CameraControlsModel" />
                         </p:TypeAnnotation>
                       </Pin>
@@ -8673,12 +8654,12 @@
                     <Patch Id="VjCeoHmz1CMPW0hwrCzBPZ" Name="GoToState">
                       <Pin Id="PXOHAgVvt6xO8NWpQYrRe5" Name="Filter Time" Kind="InputPin" />
                       <Pin Id="ECUURrPXc0gLKTX4GZhFQb" Name="To" Kind="InputPin">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Cameras.Animation.Models" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Cameras.Animation.Models" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="TypeFlag" Name="CameraModel" />
                         </p:TypeAnnotation>
                       </Pin>
                       <Pin Id="JhELwG9QmGqM5R6iE0Ru8F" Name="Go" Kind="InputPin">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Boolean" />
                         </p:TypeAnnotation>
                       </Pin>
@@ -8691,14 +8672,14 @@
 
 -->
                 <Node Name="CameraView" Bounds="-208,249" Id="OxsZOBYy54GM5Uo4IKZ7tE">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                     <Choice Kind="ContainerDefinition" Name="Process" />
                   </p:NodeReference>
                   <Patch Id="DqaeIBSdesPL19cWKZ1h3C">
                     <Canvas Id="KEoCy6YM3IjQFsZ3dtv0Jj" CanvasType="Group">
                       <ControlPoint Id="D1B8X9XLsaRLiQnNC72txx" Bounds="472,280" />
                       <Node Bounds="470,341,586,26" Id="VXN2JDEFeszQO5WK17x182">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras.Animation.Models.CameraModel" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Split" />
                           <CategoryReference Kind="RecordType" Name="CameraModel" NeedsToBeDirectParent="true" />
@@ -8715,7 +8696,7 @@
                         <Pin Id="V0rDndYAdHIOfKhsvTAogE" Name="Id" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="390,740,285,19" Id="KP0jSN3iehMN2fEXexFzgj">
-                        <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Stride.Engine.vl" LastDependency="VL.Stride.vl">
+                        <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Camera" />
                         </p:NodeReference>
@@ -8741,7 +8722,7 @@
                         <Pin Id="GFSJMmyV72NQQrQyn97Ucc" Name="Camera Component" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="601,404,46,19" Id="LuSD3Owwl4gLUyMnus8STw">
-                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="OperationNode" Name="Vector (Join)" />
                           <CategoryReference Kind="Category" Name="Vector3" />
                         </p:NodeReference>
@@ -8751,7 +8732,7 @@
                         <Pin Id="TPzfEgHarKXLn0EKSmtXFu" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="563,481,45,19" Id="V5cBqzwoR0MLK08VtvrlOu">
-                        <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Rotate" />
                           <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -8763,7 +8744,7 @@
                         <Pin Id="DFufGWS3amALrum9mhCIMk" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="564,535,42,19" Id="N2gTdNxy304LbOAMJyuqsc">
-                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Invert" />
                           <CategoryReference Kind="RecordType" Name="Matrix" NeedsToBeDirectParent="true" />
@@ -8772,7 +8753,7 @@
                         <Pin Id="JcqOEFobGAsPMiPwyxBzZq" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="470,474,22,19" Id="FNWiE68MHASNVxSPageVac">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="- (Negate)" />
                         </p:NodeReference>
@@ -8780,7 +8761,7 @@
                         <Pin Id="GslcKJQqzzXMFx4luCZw38" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="470,537,67,19" Id="LdB7W4oeM79MxcMcGHFHX6">
-                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Translation" />
                         </p:NodeReference>
@@ -8788,7 +8769,7 @@
                         <Pin Id="SSqeEE7TQBsQNW36svLAHE" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="470,590,25,19" Id="BToDemQukD1PWV938GkDvT">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="*" />
                         </p:NodeReference>
@@ -8797,7 +8778,7 @@
                         <Pin Id="OPG7M7YQF6JQPLDrZaTBjC" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="470,684,25,19" Id="PxLfpsUKkSqPMEj7Vdfg75">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="*" />
                         </p:NodeReference>
@@ -8806,7 +8787,7 @@
                         <Pin Id="IPRseWqBSPEO9KSHcfqZWE" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="719,516,46,19" Id="PegeFFP5OZ0Oip6QX9Npso">
-                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                           <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -8817,7 +8798,7 @@
                         <Pin Id="ANrHv43gg6FPDyLmFlZzzp" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="719,559,67,19" Id="ORHBFBLDvyyO8fJdSj6APo">
-                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Translation" />
                         </p:NodeReference>
@@ -8829,13 +8810,13 @@
                       <ControlPoint Id="FAsUIR2dELuOhjkkWsZTq5" Bounds="676,906" />
                       <ControlPoint Id="ILE4GzLc7vMOlzjWA5CEwD" Bounds="844,616" />
                       <Node Bounds="858,677,68,19" Id="KVHdTjVkgkDL4bTrIA5J0I">
-                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Perspective (FOV RightHanded)" />
                         </p:NodeReference>
                         <Pin Id="HS2WhEjwj2yO5eVystYvss" Name="FOV" Kind="InputPin" />
                         <Pin Id="RUgiPQiwd7pNIKNHBp45gr" Name="Aspect" Kind="InputPin" DefaultValue="1">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Float32" />
                           </p:TypeAnnotation>
                         </Pin>
@@ -8844,7 +8825,7 @@
                         <Pin Id="NQNjpAG2R8MO2hU6uF2U4T" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="837,809,25,19" Id="Lb22G01PUVKMG6fMfMeJKY">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="*" />
                         </p:NodeReference>
@@ -8895,7 +8876,7 @@
                     <Patch Id="TQResL3wgVbLtSckth33gQ" Name="Update" ParticipatingElements="LuSD3Owwl4gLUyMnus8STw">
                       <Pin Id="SlFllcnWjTpPZu5LSk7DPg" Name="Components" Kind="InputPin" Bounds="409,243" />
                       <Pin Id="KJDWSlLpKsqNtR3fR04Lam" Name="Input" Kind="InputPin">
-                        <p:TypeAnnotation LastCategoryFullName="Stride.Cameras.Animation.Models" LastSymbolSource="VL.Addons.Stride.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Stride.Cameras.Animation.Models" LastDependency="VL.Addons.Stride.vl">
                           <Choice Kind="TypeFlag" Name="CameraModel" />
                         </p:TypeAnnotation>
                       </Pin>
@@ -8981,7 +8962,7 @@
                 <Pin Id="CgumQSrb2P1PmtNzkZYS67" Name="Reset" Kind="InputPin" Bounds="502,455" />
                 <Pin Id="FYz6eO4P84BOCXQKSB1Gir" Name="Pan Enabled" Kind="InputPin" Bounds="592,218" />
                 <Pin Id="LOHCx51XjlOMMYiGUSgFCL" Name="Auto Input Source" Kind="InputPin" Bounds="575,187" DefaultValue="True">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -9018,7 +8999,7 @@
 
 -->
           <Node Name="TextureSize" Bounds="70,77,182,264" Id="B5UVpGWzRuQNeWw1aDR7e9">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <p:HideCategory p:Type="Boolean">true</p:HideCategory>
@@ -9031,8 +9012,8 @@
               <ControlPoint Id="TMRlRsdZPXsNu5XGJHciGL" Bounds="146,324" />
               <Pin Id="APbncehfOuYQAChUacYbk0" Name="Output" Kind="OutputPin" Bounds="1002,351" />
               <Link Id="JTLov0OYd3fNRxBPT5MFNy" Ids="TMRlRsdZPXsNu5XGJHciGL,APbncehfOuYQAChUacYbk0" IsHidden="true" />
-              <Node Bounds="93,181,110,123" Id="EjABz0JrKyONU77g7xD31e">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+              <Node Bounds="93,181,110,124" Id="EjABz0JrKyONU77g7xD31e">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <FullNameCategoryReference ID="Primitive" />
@@ -9044,7 +9025,7 @@
                   <Patch Id="AAedDLIs23bOYqZgEca4rP" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="ME8n4kbLyuBLFDmdtuGRDe" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="105,234,44,26" Id="CxLytZuDd9rNj67k8I19v5">
-                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Category" Name="Texture" />
                       <Choice Kind="OperationCallFlag" Name="Width" />
@@ -9054,7 +9035,7 @@
                     <Pin Id="CVOBK86bviOMnnz9upMHNc" Name="Width" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="144,265,46,19" Id="GoxzlQW0BgBMk8o8DsG9jo">
-                    <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Vector2Type" Name="Vector2" />
                       <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
@@ -9064,7 +9045,7 @@
                     <Pin Id="CFUCPyn85NuL4wYCpgM3ZK" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Node Bounds="144,204,46,26" Id="B5XZddiTzw5LcWV5ZIIywx">
-                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Category" Name="Texture" />
                       <Choice Kind="OperationCallFlag" Name="Height" />
@@ -9078,7 +9059,7 @@
               <Link Id="VewiBwegr3lONovNupNbFP" Ids="CVOBK86bviOMnnz9upMHNc,Er5fQtBg0jIOYa9118Y3Gp" />
               <Link Id="V4mNDtAjcqrOmd5DwuButd" Ids="Dvy37awGhk5NzWmGPj1FzC,CZikitR1im8Oa17oc5udw1" />
               <Node Bounds="93,140,65,19" Id="E0R0gyzhWxsNu21HrkJho6">
-                <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                 </p:NodeReference>
@@ -9092,7 +9073,7 @@
               <Link Id="NrcmstiIf8GPfHsNwPLpiL" Ids="CFUCPyn85NuL4wYCpgM3ZK,MxkPqzD9k0wOCULvzr7sFh" />
               <Link Id="HBEuQXQztU5O7H01RPT47R" Ids="MxkPqzD9k0wOCULvzr7sFh,TMRlRsdZPXsNu5XGJHciGL" />
               <Pad Id="OirLdcjbfZmOYKkC1O5uv5" Comment="" Bounds="186,142,35,28" ShowValueBox="true" isIOBox="true">
-                <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Vector2" />
                 </p:TypeAnnotation>
               </Pad>
@@ -9105,7 +9086,7 @@
 
 -->
           <Node Name="TextureSize (Int2)" Bounds="297,76,182,274" Id="MuLOHphKR8bNz22TyZ8OB0">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <p:HideCategory p:Type="Boolean">true</p:HideCategory>
@@ -9118,7 +9099,7 @@
               <Pin Id="S7virRGPRrSQQsgs3C2B3U" Name="Output" Kind="OutputPin" Bounds="1002,351" />
               <Link Id="U9DOwO1wDRGL9FjUkG49cz" Ids="MZc9KE7ZsRVNxj52ctEvvV,S7virRGPRrSQQsgs3C2B3U" IsHidden="true" />
               <Node Bounds="320,178,110,144" Id="UN9KUAmqLtpNfhBli72RwL">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin" LastDependency="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <FullNameCategoryReference ID="Primitive" />
@@ -9130,7 +9111,7 @@
                   <Patch Id="MVawpGjYnfzNhr23Dsf5fN" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="GbReyr6IpIvNtflP5y9Wbt" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="332,233,44,26" Id="E7yvAOvzARNN0zVdwzIvYi">
-                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Category" Name="Texture" />
                       <Choice Kind="OperationCallFlag" Name="Width" />
@@ -9140,7 +9121,7 @@
                     <Pin Id="FFfKq70wcQTMLwAuhZe0mC" Name="Width" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="359,201,46,26" Id="EGu59MEvtGVNWycCs97lFB">
-                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl" LastDependency="VL.Stride.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Category" Name="Texture" />
                       <Choice Kind="OperationCallFlag" Name="Height" />
@@ -9150,7 +9131,7 @@
                     <Pin Id="B5C92iclbrWLi7pSDvJavr" Name="Height" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="371,282,34,19" Id="G75ghJf7vzAMmDkaJ88xBK">
-                    <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Int2" />
                       <Choice Kind="OperationCallFlag" Name="Int2 (Create)" />
@@ -9162,7 +9143,7 @@
                 </Patch>
               </Node>
               <Node Bounds="320,139,65,19" Id="RrgHbx8dhwnNEBWZx4xX5k">
-                <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl" LastDependency="VL.CoreLib.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                 </p:NodeReference>
@@ -9179,7 +9160,7 @@
               <Link Id="V76ArlaWfkLNVv4TJuCbaQ" Ids="F2Y1uSloUVVPChRASgibKc,NR4K4EbceSeOnv41BVmJJk" />
               <Link Id="AqvPdU1XQRVQBh5Itjb63s" Ids="UXBnb7OiDGcP5ql6SVEOvO,TW3MQWaHKanNXBRelus8rU" />
               <Pad Id="NIq8iQ8hTX3NJZ6dIqmU6s" Comment="" Bounds="413,138,35,28" ShowValueBox="true" isIOBox="true">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Int2" />
                 </p:TypeAnnotation>
               </Pad>
@@ -9210,7 +9191,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="SeF1XJDWKKVMFCcSlHilsh" Location="VL.Stride" IsFriend="true" Version="2022.5.0-0485-g8f46e4a34a" />
+  <NugetDependency Id="SeF1XJDWKKVMFCcSlHilsh" Location="VL.Stride" IsFriend="true" Version="2022.5.0-0696-g73767f5671" />
   <PlatformDependency Id="MLVA0izfRMkORdIZzd9kvt" Location="../../../../_vvvv/vvvv_gamma_2022.5.0-0485-g8f46e4a34a/Stride.dll" />
   <PlatformDependency Id="CvdCU2DNQlRMaSdivNSZJy" Location="../../../../_vvvv/vvvv_gamma_2022.5.0-0485-g8f46e4a34a/Stride.Graphics.dll" />
   <PlatformDependency Id="CfSqI9CZTJZLV5hRh33DGP" Location="../../../../_vvvv/vvvv_gamma_2022.5.0-0485-g8f46e4a34a/Stride.Core.dll" />


### PR DESCRIPTION
I'd like to open a discussion regarding the names and UX of the TextureArray nodes.

when patching, conceptually a TextureArray behaves very similar to a MutableArray. since all mutable types (MutableArray, SpreadBuilder, ...) use "SetItem" and "GetItem" as node names for the respective nodes I would propose a name change of the "GetSlice" and "SetSlice" nodes.

Furthermore, in the current "SetSlice" node, an input texture can only be set by changing the value on the Index-Pin (therefore implicitly setting the texture). This has the disadvantage that a changing texture-source connected to an input (think webcam, etc.) cannot be updated on the same index.
I'd propose making the texture update on the array explicit by adding an "Apply" pin on "SetItem".

What are your thoughts on this topic?